### PR TITLE
chore(apps/sample-api): chore(apps/sample-api): update vue-nobundler …

### DIFF
--- a/apps/sample-api/public/vue-nobundler/index.html
+++ b/apps/sample-api/public/vue-nobundler/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" crossorigin="anonymous" integrity="sha384-HmYpsz2Aa9Gh3JlkCoh8kUJ2mUKJKTnkyC2Lzt8aLzpPOpnDe8KpFE2xNiBpMDou">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="data:,">
   <title>VueJS No Webpack Template</title>
@@ -18,8 +18,8 @@
   </div>
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   <!-- to get latest & integrity sha... https://unpkg.com/vue?meta -->
-  <script src="https://unpkg.com/vue@3.3.4" crossorigin="anonymous" integrity="sha384-3QkgNmJ54e06hSufVW1cfVa+tPTYFCaFiat0JgSkZgIjasMRDQg7Bc0KWR3OgKt1"></script>
-  <script src="https://unpkg.com/vue-router@4.2.4" crossorigin="anonymous" integrity="sha384-6a/6j7HELWdyi1qeawTgNrxnaqw0oH2ax4dJdS/GlUliZkDoqSxE+FeKS+9lbig3"></script>
+  <script src="https://unpkg.com/vue@3.5.34/dist/vue.global.prod.js" crossorigin="anonymous" integrity="sha384-o/dkigrGbFcEo9IQnKb3UkoDe43ZnvA9D531VRI1eaHuP+QiVLB7YYAxGnIEoe+t"></script>
+  <script src="https://unpkg.com/vue-router@4.6.4/dist/vue-router.global.prod.js" crossorigin="anonymous" integrity="sha384-A4bHjHQxfxIvuD8PBtwmSWs3Iu2iAYs4ay5uVK2xBRObO41s5ZQF3016uyadsK/V"></script>
   <script type="module" src="main.js"></script>
   <script>
     console.log('main.js 500 errors could be due to CORS origin of http server serving the page')
@@ -36,6 +36,6 @@
       document.querySelector('#vanilla').innerHTML = aa.default.template
     }
   </script>
-  <script defer src="https://use.fontawesome.com/releases/v5.14.0/js/all.js"></script>
+  <script defer src="https://use.fontawesome.com/releases/v5.15.4/js/all.js" crossorigin="anonymous" integrity="sha384-rOA1PnstxnOBLzCLMcre8ybwbTmemjzdNlILg8O7z1lUkLXozs4DHonlDtnE7fpc"></script>
 </body>
 </html>


### PR DESCRIPTION
## Pull Request Checklist

- [ ] I read and followed the [Contribution guide](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)
- [ ] I linked the related issue, if one exists
- [x] I ran the relevant checks or tests for the affected area

## Summary

Update outdated CDN dependencies and add missing Subresource Integrity (SRI) attributes in `vue-nobundler/index.html`.

Bulma and Font Awesome were loaded from CDN without `integrity` attributes, meaning the browser could not verify the files had not been tampered with — a supply chain attack risk. Vue and vue-router had SRI but their hashes were tied to outdated versions. All four resources are now pinned to their latest stable versions with correct `integrity` + `crossorigin` attributes.

CDN URLs for Vue and vue-router were also corrected from implicit redirect paths (`/unpkg.com/vue@3.3.4`) to explicit build file paths (`vue.global.prod.js` / `vue-router.global.prod.js`), making resolution deterministic and SRI hashes verifiable.

| Package | Before | After |
|---|---|---|
| Vue | 3.3.4 | 3.5.34 |
| vue-router | 4.2.4 | 4.6.4 |
| Bulma | 0.9.1 (no SRI) | 0.9.4 + SRI |
| Font Awesome | 5.14.0 (no SRI) | 5.15.4 + SRI |

## Affected Area

- [x] apps
- [ ] common
- [ ] docs
- [ ] scripts
- [ ] CI/CD or GitHub Actions

## Validation

```text
# Verify SRI hashes match the downloaded files
curl -s https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css | openssl dgst -sha384 -binary | openssl base64 -A
curl -s https://unpkg.com/vue@3.5.34/dist/vue.global.prod.js | openssl dgst -sha384 -binary | openssl base64 -A
curl -s https://unpkg.com/vue-router@4.6.4/dist/vue-router.global.prod.js | openssl dgst -sha384 -binary | openssl base64 -A
curl -s https://use.fontawesome.com/releases/v5.15.4/js/all.js | openssl dgst -sha384 -binary | openssl base64 -A

# Manual check: start sample-api and open /native/index.html in browser,
# verify no SRI errors in the console and the page renders correctly
