### PR TITLE
(apps/sample-vue-full): suppress Biome false-positive unused import warnings

### DIFF
--- a/apps/sample-vue-full/components/MemberCard.vue
+++ b/apps/sample-vue-full/components/MemberCard.vue
@@ -1,0 +1,81 @@
+<template>
+  <a-card class="member-card" :bordered="false" hoverable>
+    <div class="member-inner">
+      <a-avatar :size="52" :style="{ background: avatarColor, fontFamily: 'DM Sans, sans-serif', fontSize: '20px', fontWeight: 700, flexShrink: 0 }">
+        {{ initials }}
+      </a-avatar>
+      <div class="member-info">
+        <span class="member-name">{{ name }}</span>
+        <a-tag class="member-role-tag" :color="tagColor">{{ role }}</a-tag>
+      </div>
+    </div>
+  </a-card>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  name: { type: String, required: true },
+  role: { type: String, required: true },
+  avatarColor: { type: String, default: '#4f46e5' },
+  tagColor: { type: String, default: 'purple' },
+});
+
+const initials = computed(() =>
+  props.name
+    .split(' ')
+    .map(w => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2),
+);
+</script>
+
+<style scoped>
+.member-card {
+  border-radius: 12px;
+  border: 1px solid #e2e8f0 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.2s, transform 0.2s, border-color 0.2s;
+}
+
+.member-card:hover {
+  border-color: #a5b4fc !important;
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.18);
+  transform: translateY(-2px);
+}
+
+:deep(.member-card .ant-card-body) {
+  padding: 16px;
+}
+
+.member-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.member-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.member-name {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.member-role-tag {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  width: fit-content;
+}
+</style>

--- a/apps/sample-vue-full/components/StatCard.vue
+++ b/apps/sample-vue-full/components/StatCard.vue
@@ -78,10 +78,6 @@ const computedValueStyle = computed(() => {
   transform: scale(1.12);
 }
 
-.stat-icon-wrap {
-  transition: transform 0.22s ease;
-}
-
 :deep(.stat-card .ant-card-body) {
   padding: 20px 24px;
 }
@@ -106,6 +102,7 @@ const computedValueStyle = computed(() => {
   border-radius: 9px;
   display: flex;
   align-items: center;
+  transition: transform 0.22s ease;
   justify-content: center;
   flex-shrink: 0;
 }

--- a/apps/sample-vue-full/components/StatCard.vue
+++ b/apps/sample-vue-full/components/StatCard.vue
@@ -13,9 +13,8 @@
       :suffix="suffix"
       :value-style="computedValueStyle"
     >
-      <template v-if="trend" #prefix>
-        <ArrowUpOutlined v-if="trend === 'up'" />
-        <ArrowDownOutlined v-if="trend === 'down'" />
+      <template v-if="trendIcon" #prefix>
+        <component :is="trendIcon" />
       </template>
     </a-statistic>
 
@@ -24,8 +23,7 @@
         class="stat-trend-badge"
         :class="trend === 'up' ? 'stat-trend-badge--up' : trend === 'down' ? 'stat-trend-badge--down' : ''"
       >
-        <ArrowUpOutlined v-if="trend === 'up'" />
-        <ArrowDownOutlined v-if="trend === 'down'" />
+        <component :is="trendIcon" />
         {{ footer }}
       </span>
     </div>
@@ -46,6 +44,12 @@ const props = defineProps({
   icon: { type: Object, required: true },
   iconBg: { type: String, default: '#eef2ff' },
   valueColor: { type: String, default: '' },
+});
+
+const trendIcon = computed(() => {
+  if (props.trend === 'up') return ArrowUpOutlined;
+  if (props.trend === 'down') return ArrowDownOutlined;
+  return null;
 });
 
 const computedValueStyle = computed(() => {

--- a/apps/sample-vue-full/components/StatCard.vue
+++ b/apps/sample-vue-full/components/StatCard.vue
@@ -1,0 +1,141 @@
+<template>
+  <a-card class="stat-card" :bordered="false">
+    <div class="stat-top">
+      <span class="stat-label">{{ title }}</span>
+      <div class="stat-icon-wrap" :style="{ background: iconBg }">
+        <component :is="icon" class="stat-icon" />
+      </div>
+    </div>
+
+    <a-statistic
+      :value="value"
+      :precision="precision"
+      :suffix="suffix"
+      :value-style="computedValueStyle"
+    >
+      <template v-if="trend" #prefix>
+        <ArrowUpOutlined v-if="trend === 'up'" />
+        <ArrowDownOutlined v-if="trend === 'down'" />
+      </template>
+    </a-statistic>
+
+    <div v-if="footer" class="stat-footer">
+      <span
+        class="stat-trend-badge"
+        :class="trend === 'up' ? 'stat-trend-badge--up' : trend === 'down' ? 'stat-trend-badge--down' : ''"
+      >
+        <ArrowUpOutlined v-if="trend === 'up'" />
+        <ArrowDownOutlined v-if="trend === 'down'" />
+        {{ footer }}
+      </span>
+    </div>
+  </a-card>
+</template>
+
+<script setup>
+import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons-vue';
+import { computed } from 'vue';
+
+const props = defineProps({
+  title: { type: String, required: true },
+  value: { type: Number, required: true },
+  precision: { type: Number, default: 0 },
+  suffix: { type: String, default: '' },
+  trend: { type: String, default: null }, // 'up' | 'down' | null
+  footer: { type: String, default: '' },
+  icon: { type: Object, required: true },
+  iconBg: { type: String, default: '#eef2ff' },
+  valueColor: { type: String, default: '' },
+});
+
+const computedValueStyle = computed(() => {
+  if (props.valueColor) return { color: props.valueColor };
+  if (props.trend === 'up') return { color: '#16a34a' };
+  if (props.trend === 'down') return { color: '#dc2626' };
+  return { color: '#0f172a' };
+});
+</script>
+
+<style scoped>
+.stat-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+  transition: transform 0.22s ease, box-shadow 0.22s ease;
+  cursor: default;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.stat-card:hover .stat-icon-wrap {
+  transform: scale(1.12);
+}
+
+.stat-icon-wrap {
+  transition: transform 0.22s ease;
+}
+
+:deep(.stat-card .ant-card-body) {
+  padding: 20px 24px;
+}
+
+.stat-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.stat-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: #64748b;
+}
+
+.stat-icon-wrap {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.stat-icon {
+  font-size: 16px;
+}
+
+:deep(.ant-statistic-content) {
+  font-family: 'DM Sans', sans-serif;
+}
+
+:deep(.ant-statistic-content-value) {
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.stat-footer {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #f1f5f9;
+}
+
+.stat-trend-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  color: #64748b;
+}
+
+.stat-trend-badge--up   { color: #16a34a; }
+.stat-trend-badge--down { color: #dc2626; }
+</style>

--- a/apps/sample-vue-full/layouts/Secure.css
+++ b/apps/sample-vue-full/layouts/Secure.css
@@ -1,47 +1,6 @@
-.trigger {
-  font-size: 18px;
-  line-height: 64px;
-  padding: 0 24px;
-  cursor: pointer;
-  transition: color 0.3s;
-}
-
-.trigger:hover {
-  color: #1890ff;
-}
-
-.site-layout .site-layout-background {
-  background: #fff;
-}
-
-.ant-layout-sider-children {
-  background-color: blue;
-}
-
-.ant-layout-sider-children .sider-logo {
-  height: 32px;
-  background: rgba(255, 255, 255, 0.3);
-  margin: 16px;
-  background-image: url('https://via.placeholder.com/168x32.png?text=A+Logo');
-}
-
-.ant-layout-sider-children .sider-menu {
-  overflow-y: auto;
-  height: calc(100vh - 64px);
-}
-
-.ant-menu {
-  background-color: var(--blue-something);
-}
-
-.ant-menu-item {
-  background-color: var(--blue-something);
-}
-
-/*
-.ant-menu { background-color: gray; }
-.ant-menu-dark.ant-menu-inline .ant-menu-sub.ant-menu-inline { background-color: red; }
-.ant-menu-item, .ant-menu-item:hover { background-color: var(--blue-something); }
-.ant-menu-item.ant-menu-item-active, .ant-menu-item.ant-menu-item-active:hover { background-color: orange; }
-.ant-menu-item:not(.ant-menu-item-selected), .ant-menu-item:not(.ant-menu-item-selected):hover { background-color: pink; }
+/* Secure layout styles have been moved to scoped styles in:
+   - layouts/Secure.vue
+   - layouts/components/AppSidebar.vue
+   - layouts/components/AppHeader.vue
+   - layouts/components/AppFooter.vue
 */

--- a/apps/sample-vue-full/layouts/Secure.vue
+++ b/apps/sample-vue-full/layouts/Secure.vue
@@ -1,93 +1,124 @@
 <template>
-  <a-layout>
-    <bwc-loading-overlay v-if="loading"></bwc-loading-overlay>
+  <a-layout class="secure-layout">
+    <bwc-loading-overlay v-if="loading" />
     <a-back-top />
-    <a-layout-sider v-model:collapsed="collapsed" :trigger="null" collapsible :collapsed-width="0">
-      <div class="sider-logo" />
-      <a-menu class="sider-menu" theme="dark" mode="inline" v-model:selectedKeys="selectedKeys">
-        <template v-for="route in mappedRoutes">
-          <a-sub-menu v-if="route.submenu" :key="route.submenu" :title="toPascalCase(route.submenu)">
-            <a-menu-item v-for="menu in subMenus[route.submenu]" :key="`sm-${menu.path}`" @click="$router.push(menu)"
-              >{{ menu.name }}</a-menu-item
-            >
-          </a-sub-menu>
-          <a-menu-item v-else :key="`m-${route.path}`" @click="$router.push(route)">{{ route.name }}</a-menu-item>
-        </template>
-        <a-menu-item data-cy="logout" key="logout" @click="logout">Logout</a-menu-item>
-      </a-menu>
-    </a-layout-sider>
-    <a-layout>
-      <a-layout-header style="background: #fff; padding: 0">
-        <menu-unfold-outlined v-if="collapsed" class="trigger" @click="() => (collapsed = !collapsed)" />
-        <menu-fold-outlined v-else class="trigger" @click="() => (collapsed = !collapsed)" />
-        <span>Sample App</span>
-      </a-layout-header>
-      <a-layout-content
-        :style="{ overflowY: 'auto', margin: '8px 8px', padding: '8px', background: '#fff', height: 'calc(100vh - 96px)' }"
-      >
-        <a-breadcrumb style="margin: 8px 0">
-          <a-breadcrumb-item>Home</a-breadcrumb-item>
-          <a-breadcrumb-item>Dashboard</a-breadcrumb-item>
-        </a-breadcrumb>
-        <router-view :key="$route.fullPath"></router-view>
+
+    <AppSidebar
+      v-model:collapsed="collapsed"
+      :mapped-routes="mappedRoutes"
+      :sub-menus="subMenus"
+      brand-icon="N"
+      brand-name="novex"
+      @logout="logout"
+    />
+
+    <Transition name="backdrop-fade">
+      <div v-if="!collapsed" class="mobile-backdrop" @click="collapsed = true" />
+    </Transition>
+
+    <a-layout class="main-layout">
+      <AppHeader
+        v-model:collapsed="collapsed"
+        :notifications="notifications"
+        :messages="messages"
+        user-label="U"
+        @logout="logout"
+        @notif-read="markNotifRead"
+        @notif-read-all="markAllNotifsRead"
+        @message-read="markMessageRead"
+        @message-read-all="markAllMessagesRead"
+      />
+
+      <a-layout-content class="main-content">
+        <router-view :key="$route.fullPath" />
       </a-layout-content>
-      <a-layout-footer hidden style="text-align: center">Ant Design ©2023</a-layout-footer>
+
+      <AppFooter brand="novex" />
     </a-layout>
   </a-layout>
 </template>
 
 <script setup>
 import idleTimer from '@common/web/idle';
-// :key="$route.fullPath" // this is causing problems
 import { computed, onBeforeUnmount, onMounted, onUnmounted, reactive, ref } from 'vue';
 import { onLogin, onLogout } from '../setups/events.js';
 import { SECURE_ROUTES } from '../setups/routes.js';
 import { useMainStore } from '../store.js';
+import AppFooter from './components/AppFooter.vue';
+import AppHeader from './components/AppHeader.vue';
+import AppSidebar from './components/AppSidebar.vue';
 
 const store = useMainStore();
-// const loading = store.loading
 const mappedRoutes = reactive([]);
 const subMenus = reactive({});
 const loading = computed(() => store.loading);
-const selectedKeys = ref(['1']);
 const collapsed = ref(false);
 
-const toPascalCase = str => {
-  str = str.replace(/-\w/g, x => ` ${x[1].toUpperCase()}`);
-  return str[0].toUpperCase() + str.substring(1, str.length);
+/* ── Notifications ── */
+const notifications = ref([
+  { id: 1, message: 'New user registered', time: '2 min ago', read: false },
+  { id: 2, message: 'Server deployment completed', time: '1 hr ago', read: false },
+  { id: 3, message: 'Weekly report is ready', time: 'Yesterday', read: true },
+]);
+
+const markNotifRead = id => {
+  const n = notifications.value.find(n => n.id === id);
+  if (n) n.read = true;
 };
 
+const markAllNotifsRead = () => {
+  notifications.value.forEach(n => {
+    n.read = true;
+  });
+};
+
+/* ── Messages ── */
+const messages = ref([
+  { id: 1, name: 'Aaron Gong', initials: 'AG', preview: 'Can you review the PR?', time: '5 min ago', read: false },
+  { id: 2, name: 'Tech Lead', initials: 'TL', preview: 'Deploy is ready for staging', time: '30 min ago', read: false },
+  { id: 3, name: 'System', initials: 'SY', preview: 'Scheduled maintenance tonight', time: '2 hr ago', read: true },
+]);
+
+const markMessageRead = id => {
+  const m = messages.value.find(m => m.id === id);
+  if (m) m.read = true;
+};
+
+const markAllMessagesRead = () => {
+  messages.value.forEach(m => {
+    m.read = true;
+  });
+};
+
+/* ── Routes ── */
 onMounted(async () => {
   console.log('SECURE mounted!');
   idleTimer.timeouts.push({ time: 300, fn: () => alert('Idle Timeout Test'), stop: true });
   idleTimer.start();
 
-  SECURE_ROUTES.filter(route => route.meta.layout === 'layout-secure').forEach(route => {
-    if (!route.hidden) {
-      const pathLen = route.path.split('/').length;
-      if (pathLen === 2 || pathLen === 3) {
-        const submenu = pathLen === 3 ? route.path.split('/', 2)[1] : '';
-        // console.log('submenu', route, '-', submenu, '-', pathLen)
-        if (submenu) {
-          if (!subMenus[submenu]) {
-            // first time
-            subMenus[submenu] = [];
-            mappedRoutes.push({ ...route, submenu: submenu });
-          }
-          subMenus[submenu].push({ ...route }); // add item
-        } else {
-          mappedRoutes.push({ ...route, submenu: '' }); // add item
+  SECURE_ROUTES.filter(route => !route.hidden).forEach(route => {
+    const pathLen = route.path.split('/').length;
+    if (pathLen === 2 || pathLen === 3) {
+      const submenu = pathLen === 3 ? route.path.split('/', 2)[1] : '';
+      if (submenu) {
+        if (!subMenus[submenu]) {
+          subMenus[submenu] = [];
+          mappedRoutes.push({ ...route, submenu });
         }
+        subMenus[submenu].push({ ...route });
+      } else {
+        mappedRoutes.push({ ...route, submenu: '' });
       }
     }
   });
   onLogin?.();
 });
+
 onUnmounted(() => {
   console.log('SECURE unmounted');
 });
+
 onBeforeUnmount(() => {
-  // close WS
   idleTimer.stop();
   onLogout?.();
 });
@@ -101,6 +132,41 @@ const logout = async () => {
 };
 </script>
 
-<style>
-@import 'Secure.css';
+<style scoped>
+.secure-layout {
+  min-height: 100vh;
+  background: #f1f5f9;
+}
+
+.main-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  background: #f1f5f9;
+}
+
+.mobile-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 199;
+}
+
+.backdrop-fade-enter-active,
+.backdrop-fade-leave-active { transition: opacity 0.2s ease; }
+.backdrop-fade-enter-from,
+.backdrop-fade-leave-to { opacity: 0; }
+
+@media (max-width: 767px) {
+  .mobile-backdrop { display: block; }
+  .main-content { padding: 16px; }
+}
 </style>

--- a/apps/sample-vue-full/layouts/Secure.vue
+++ b/apps/sample-vue-full/layouts/Secure.vue
@@ -44,8 +44,11 @@ import { computed, onBeforeUnmount, onMounted, onUnmounted, reactive, ref } from
 import { onLogin, onLogout } from '../setups/events.js';
 import { SECURE_ROUTES } from '../setups/routes.js';
 import { useMainStore } from '../store.js';
+// biome-ignore lint/correctness/noUnusedImports: components used in Vue template
 import AppFooter from './components/AppFooter.vue';
+// biome-ignore lint/correctness/noUnusedImports: components used in Vue template
 import AppHeader from './components/AppHeader.vue';
+// biome-ignore lint/correctness/noUnusedImports: components used in Vue template
 import AppSidebar from './components/AppSidebar.vue';
 
 const store = useMainStore();

--- a/apps/sample-vue-full/layouts/components/AppFooter.vue
+++ b/apps/sample-vue-full/layouts/components/AppFooter.vue
@@ -1,0 +1,58 @@
+<template>
+  <a-layout-footer class="app-footer">
+    <span class="footer-brand">{{ brand }}</span>
+    <span class="footer-sep">·</span>
+    <span class="footer-copy">{{ year }} All rights reserved</span>
+  </a-layout-footer>
+</template>
+
+<script setup>
+defineProps({
+  brand: { type: String, default: 'novex' },
+});
+
+const year = new Date().getFullYear();
+</script>
+
+<style scoped>
+.app-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 24px;
+  background: #f8fafc;
+  border-top: 1px solid #e2e8f0;
+  flex-shrink: 0;
+}
+
+.footer-brand {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  color: #4f46e5;
+  letter-spacing: 0.06em;
+}
+
+.footer-sep {
+  color: #cbd5e1;
+  font-size: 12px;
+}
+
+.footer-copy {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+@media (max-width: 767px) {
+  .app-footer {
+    padding: 0 16px;
+    flex-wrap: wrap;
+    height: auto;
+    min-height: 40px;
+    gap: 4px;
+  }
+}
+</style>

--- a/apps/sample-vue-full/layouts/components/AppHeader.vue
+++ b/apps/sample-vue-full/layouts/components/AppHeader.vue
@@ -1,0 +1,475 @@
+<template>
+  <a-layout-header class="app-header">
+
+    <!-- Left: toggle + breadcrumb -->
+    <div class="header-left">
+      <a-button type="text" class="toggle-btn" @click="$emit('update:collapsed', !collapsed)">
+        <template #icon>
+          <MenuUnfoldOutlined v-if="collapsed" />
+          <MenuFoldOutlined v-else />
+        </template>
+      </a-button>
+
+      <a-breadcrumb class="header-breadcrumb">
+        <a-breadcrumb-item>
+          <router-link to="/dashboard">Home</router-link>
+        </a-breadcrumb-item>
+        <a-breadcrumb-item v-if="currentRoute.name">
+          {{ currentRoute.name }}
+        </a-breadcrumb-item>
+      </a-breadcrumb>
+    </div>
+
+    <!-- Right: search, chat, bell, divider, user -->
+    <div class="header-right">
+
+      <!-- Search -->
+      <Transition name="search-switch" mode="out-in">
+        <a-input
+          v-if="searchOpen"
+          key="search"
+          ref="searchInputRef"
+          v-model:value="searchQuery"
+          placeholder="Search..."
+          class="search-input-field"
+          @keydown.esc="closeSearch"
+        >
+          <template #prefix><SearchOutlined /></template>
+          <template #suffix>
+            <a-button type="text" size="small" class="search-close-btn" @click="closeSearch">
+              <template #icon><CloseOutlined /></template>
+            </a-button>
+          </template>
+        </a-input>
+        <a-button v-else key="search-btn" type="text" class="icon-btn" @click="openSearch">
+          <template #icon><SearchOutlined /></template>
+        </a-button>
+      </Transition>
+
+      <!-- Chat -->
+      <a-popover trigger="click" placement="bottomRight" :overlay-inner-style="{ padding: 0 }" :overlay-style="{ width: '320px' }">
+        <template #content>
+          <div class="panel-head">
+            <span class="panel-title">Messages</span>
+            <a-button v-if="unreadMessages" type="link" size="small" @click="emit('message-read-all')">
+              Mark all read
+            </a-button>
+          </div>
+          <a-list size="small" :data-source="messages" class="panel-list">
+            <template #renderItem="{ item }">
+              <a-list-item class="panel-item" :class="{ 'panel-item--unread': !item.read }" @click="emit('message-read', item.id)">
+                <a-list-item-meta>
+                  <template #avatar>
+                    <a-badge :dot="!item.read" color="#4f46e5">
+                      <a-avatar class="chat-avatar">{{ item.initials }}</a-avatar>
+                    </a-badge>
+                  </template>
+                  <template #title>
+                    <div class="chat-title-row">
+                      <span class="chat-name">{{ item.name }}</span>
+                      <span class="item-time">{{ item.time }}</span>
+                    </div>
+                  </template>
+                  <template #description>{{ item.preview }}</template>
+                </a-list-item-meta>
+              </a-list-item>
+            </template>
+          </a-list>
+        </template>
+        <a-badge :count="unreadMessages" :overflow-count="9">
+          <a-button type="text" class="icon-btn" aria-label="Messages">
+            <template #icon><MessageOutlined /></template>
+          </a-button>
+        </a-badge>
+      </a-popover>
+
+      <!-- Notifications -->
+      <a-popover trigger="click" placement="bottomRight" :overlay-inner-style="{ padding: 0 }" :overlay-style="{ width: '320px' }">
+        <template #content>
+          <div class="panel-head">
+            <span class="panel-title">Notifications</span>
+            <a-button v-if="unreadCount" type="link" size="small" @click="emit('notif-read-all')">
+              Mark all read
+            </a-button>
+          </div>
+          <a-list size="small" :data-source="notifications" class="panel-list">
+            <template #renderItem="{ item }">
+              <a-list-item class="panel-item" :class="{ 'panel-item--unread': !item.read }" @click="emit('notif-read', item.id)">
+                <a-list-item-meta :description="item.time">
+                  <template #avatar>
+                    <div class="notif-dot" :class="{ 'notif-dot--active': !item.read }" />
+                  </template>
+                  <template #title>{{ item.message }}</template>
+                </a-list-item-meta>
+              </a-list-item>
+            </template>
+          </a-list>
+        </template>
+        <a-badge :count="unreadCount" :overflow-count="9">
+          <a-button type="text" class="icon-btn" aria-label="Notifications">
+            <template #icon><BellOutlined /></template>
+          </a-button>
+        </a-badge>
+      </a-popover>
+
+      <a-divider type="vertical" class="header-divider" />
+
+      <!-- User dropdown -->
+      <a-dropdown trigger="click" placement="bottomRight">
+        <a-avatar class="user-avatar">{{ userLabel }}</a-avatar>
+        <template #overlay>
+          <a-menu>
+            <a-menu-item key="profile">
+              <UserOutlined style="margin-right:8px" />Profile
+            </a-menu-item>
+            <a-menu-divider />
+            <a-menu-item key="logout" class="logout-item" @click="$emit('logout')">
+              <LogoutOutlined style="margin-right:8px" />Logout
+            </a-menu-item>
+          </a-menu>
+        </template>
+      </a-dropdown>
+
+    </div>
+  </a-layout-header>
+</template>
+
+<script setup>
+import {
+  BellOutlined,
+  CloseOutlined,
+  LogoutOutlined,
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
+  MessageOutlined,
+  SearchOutlined,
+  UserOutlined,
+} from '@ant-design/icons-vue';
+import { computed, nextTick, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+const props = defineProps({
+  collapsed: { type: Boolean, required: true },
+  notifications: { type: Array, default: () => [] },
+  messages: { type: Array, default: () => [] },
+  userLabel: { type: String, default: 'U' },
+});
+
+const emit = defineEmits([
+  'update:collapsed',
+  'logout',
+  'notif-read',
+  'notif-read-all',
+  'message-read',
+  'message-read-all',
+]);
+
+const route = useRoute();
+const currentRoute = computed(() => route);
+
+/* ── Search ── */
+const searchOpen = ref(false);
+const searchQuery = ref('');
+const searchInputRef = ref(null);
+
+const openSearch = async () => {
+  searchOpen.value = true;
+  await nextTick();
+  searchInputRef.value?.focus();
+};
+
+const closeSearch = () => {
+  searchOpen.value = false;
+  searchQuery.value = '';
+};
+
+/* ── Computed counts ── */
+const unreadCount = computed(() => props.notifications.filter(n => !n.read).length);
+const unreadMessages = computed(() => props.messages.filter(m => !m.read).length);
+</script>
+
+<style scoped>
+/* ── Layout ── */
+.app-header {
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+  background: #ffffff !important;
+  padding: 0 16px 0 8px !important;
+  height: 56px !important;
+  line-height: normal !important;
+  border-bottom: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+/* ── Toggle & icon buttons ── */
+:deep(.toggle-btn.ant-btn),
+:deep(.icon-btn.ant-btn) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  color: #64748b;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+:deep(.toggle-btn.ant-btn:hover),
+:deep(.icon-btn.ant-btn:hover) {
+  background: #f1f5f9 !important;
+  color: #4f46e5 !important;
+}
+
+.header-breadcrumb {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  overflow: hidden;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+:deep(.header-breadcrumb .ant-breadcrumb-link a) {
+  color: #64748b;
+  text-decoration: none;
+}
+
+:deep(.header-breadcrumb .ant-breadcrumb-link a:hover) {
+  color: #4f46e5;
+}
+
+:deep(.header-breadcrumb .ant-breadcrumb-link) {
+  color: #1e293b;
+  font-weight: 500;
+}
+
+:deep(.header-breadcrumb .ant-breadcrumb-separator) {
+  color: #cbd5e1;
+}
+
+/* ── Search input ── */
+:deep(.search-input-field.ant-input-affix-wrapper) {
+  height: 36px;
+  border-radius: 9px;
+  border: 1.5px solid #a5b4fc;
+  background: #f8fafc;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  width: 200px;
+  flex-shrink: 1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+:deep(.search-input-field.ant-input-affix-wrapper:focus-within) {
+  border-color: #4f46e5 !important;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15) !important;
+  background: #fff;
+}
+
+:deep(.search-input-field .ant-input) {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  background: transparent;
+}
+
+:deep(.search-input-field .ant-input-prefix) {
+  color: #94a3b8;
+  margin-right: 6px;
+}
+
+.search-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+:deep(.search-close-btn.ant-btn) {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  color: #94a3b8;
+  padding: 0;
+  border-radius: 4px;
+}
+
+:deep(.search-close-btn.ant-btn:hover) {
+  color: #ef4444 !important;
+  background: #fef2f2 !important;
+}
+
+/* prevent right-side items from ever shrinking */
+.header-right > * {
+  flex-shrink: 0;
+}
+
+/* ── Popover badge ── */
+:deep(.ant-badge-count) {
+  box-shadow: 0 0 0 2px #fff;
+  font-size: 10px;
+  min-width: 16px;
+  height: 16px;
+  line-height: 16px;
+  padding: 0 4px;
+}
+
+/* ── Divider ── */
+:deep(.header-divider.ant-divider-vertical) {
+  height: 20px;
+  border-color: #e2e8f0;
+  margin: 0;
+}
+
+/* ── User avatar ── */
+:deep(.user-avatar.ant-avatar) {
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 700;
+  cursor: pointer;
+  transition: box-shadow 0.15s;
+  width: 32px !important;
+  height: 32px !important;
+  min-width: 32px;
+  line-height: 32px;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+:deep(.user-avatar.ant-avatar:hover) {
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+/* ── Dropdown logout item ── */
+:deep(.logout-item) {
+  color: #dc2626 !important;
+}
+
+:deep(.logout-item:hover) {
+  background: #fef2f2 !important;
+}
+
+/* ── Popover panel shared ── */
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.panel-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+:deep(.panel-list .ant-list-item) {
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+:deep(.panel-list .ant-list-item:hover) {
+  background: #f8fafc;
+}
+
+:deep(.panel-item--unread .ant-list-item-meta-title) {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+:deep(.panel-list .ant-list-item-meta-description) {
+  font-size: 12px;
+  color: #94a3b8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Chat items ── */
+:deep(.chat-avatar.ant-avatar) {
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.chat-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.chat-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.item-time {
+  font-size: 11px;
+  color: #94a3b8;
+  flex-shrink: 0;
+}
+
+/* ── Notification dot ── */
+.notif-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: transparent;
+  margin-top: 6px;
+  flex-shrink: 0;
+}
+
+.notif-dot--active {
+  background: #4f46e5;
+}
+
+/* ── Search transition ── */
+.search-switch-enter-active,
+.search-switch-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.search-switch-enter-from,
+.search-switch-leave-to {
+  opacity: 0;
+  transform: translateX(-8px);
+}
+
+/* ── Mobile ── */
+@media (max-width: 767px) {
+  .app-header {
+    padding: 0 12px 0 8px !important;
+  }
+
+  .header-breadcrumb {
+    display: none;
+  }
+}
+</style>

--- a/apps/sample-vue-full/layouts/components/AppHeader.vue
+++ b/apps/sample-vue-full/layouts/components/AppHeader.vue
@@ -317,7 +317,7 @@ const unreadMessages = computed(() => props.messages.filter(m => !m.read).length
 }
 
 :deep(.search-close-btn.ant-btn:hover) {
-  color: #ef4444 !important;
+  color: #b91c1c !important;
   background: #fef2f2 !important;
 }
 

--- a/apps/sample-vue-full/layouts/components/AppHeader.vue
+++ b/apps/sample-vue-full/layouts/components/AppHeader.vue
@@ -135,6 +135,7 @@
 </template>
 
 <script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
 import {
   BellOutlined,
   CloseOutlined,

--- a/apps/sample-vue-full/layouts/components/AppHeader.vue
+++ b/apps/sample-vue-full/layouts/components/AppHeader.vue
@@ -267,7 +267,7 @@ const unreadMessages = computed(() => props.messages.filter(m => !m.read).length
 }
 
 :deep(.header-breadcrumb .ant-breadcrumb-separator) {
-  color: #cbd5e1;
+  color: #64748b;
 }
 
 /* ── Search input ── */
@@ -297,7 +297,7 @@ const unreadMessages = computed(() => props.messages.filter(m => !m.read).length
 }
 
 :deep(.search-input-field .ant-input-prefix) {
-  color: #94a3b8;
+  color: #64748b;
   margin-right: 6px;
 }
 
@@ -311,7 +311,7 @@ const unreadMessages = computed(() => props.messages.filter(m => !m.read).length
   width: 20px;
   height: 20px;
   min-width: 20px;
-  color: #94a3b8;
+  color: #64748b;
   padding: 0;
   border-radius: 4px;
 }
@@ -404,7 +404,7 @@ const unreadMessages = computed(() => props.messages.filter(m => !m.read).length
 
 :deep(.panel-list .ant-list-item-meta-description) {
   font-size: 12px;
-  color: #94a3b8;
+  color: #64748b;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -433,7 +433,7 @@ const unreadMessages = computed(() => props.messages.filter(m => !m.read).length
 
 .item-time {
   font-size: 11px;
-  color: #94a3b8;
+  color: #64748b;
   flex-shrink: 0;
 }
 

--- a/apps/sample-vue-full/layouts/components/AppSidebar.vue
+++ b/apps/sample-vue-full/layouts/components/AppSidebar.vue
@@ -1,0 +1,215 @@
+<template>
+  <a-layout-sider
+    :collapsed="collapsed"
+    :trigger="null"
+    collapsible
+    :collapsed-width="0"
+    :width="240"
+    breakpoint="md"
+    class="app-sidebar"
+    @update:collapsed="$emit('update:collapsed', $event)"
+    @breakpoint="(broken) => $emit('update:collapsed', broken)"
+  >
+    <div class="sidebar-brand" @click="$router.push('/')">
+      <div class="brand-icon">{{ brandIcon }}</div>
+      <Transition name="fade-label">
+        <span v-if="!collapsed" class="brand-name">{{ brandName }}</span>
+      </Transition>
+    </div>
+
+    <nav class="sidebar-nav">
+      <a-menu
+        theme="dark"
+        mode="inline"
+        v-model:selectedKeys="selectedKeys"
+        class="sidebar-menu"
+      >
+        <template v-for="route in mappedRoutes" :key="route.path">
+          <a-sub-menu v-if="route.submenu" :key="route.submenu">
+            <template #title>{{ toPascalCase(route.submenu) }}</template>
+            <a-menu-item
+              v-for="menu in subMenus[route.submenu]"
+              :key="`sm-${menu.path}`"
+              @click="$router.push(menu)"
+            >
+              {{ menu.name }}
+            </a-menu-item>
+          </a-sub-menu>
+          <a-menu-item
+            v-else
+            :key="`m-${route.path}`"
+            @click="$router.push(route)"
+          >
+            {{ route.name }}
+          </a-menu-item>
+        </template>
+      </a-menu>
+    </nav>
+
+    <div class="sidebar-footer">
+      <a-button
+        type="text"
+        danger
+        block
+        data-cy="logout"
+        class="logout-btn"
+        @click="$emit('logout')"
+      >
+        <template #icon><LogoutOutlined /></template>
+        <Transition name="fade-label">
+          <span v-if="!collapsed">Logout</span>
+        </Transition>
+      </a-button>
+    </div>
+  </a-layout-sider>
+</template>
+
+<script setup>
+import { LogoutOutlined } from '@ant-design/icons-vue';
+import { ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+
+defineProps({
+  collapsed: { type: Boolean, required: true },
+  mappedRoutes: { type: Array, required: true },
+  subMenus: { type: Object, required: true },
+  brandIcon: { type: String, default: 'N' },
+  brandName: { type: String, default: 'novex' },
+});
+
+defineEmits(['update:collapsed', 'logout']);
+
+const route = useRoute();
+const selectedKeys = ref([]);
+
+const toPascalCase = str => {
+  str = str.replace(/-\w/g, x => ` ${x[1].toUpperCase()}`);
+  return str[0].toUpperCase() + str.substring(1, str.length);
+};
+
+watch(
+  () => route.path,
+  path => {
+    selectedKeys.value = [`m-${path}`];
+  },
+  { immediate: true },
+);
+</script>
+
+<style>
+.app-sidebar .ant-menu-dark { background: transparent; }
+.app-sidebar .ant-menu-dark.ant-menu-inline .ant-menu-sub.ant-menu-inline { background: rgba(0,0,0,0.2); }
+.app-sidebar .ant-menu-dark .ant-menu-item { color: #94a3b8; border-radius: 8px; margin-inline: 8px; width: calc(100% - 16px); }
+.app-sidebar .ant-menu-dark .ant-menu-item:hover { background: rgba(99,102,241,0.1) !important; color: #c7d2fe; }
+.app-sidebar .ant-menu-dark .ant-menu-item-selected { background: rgba(99,102,241,0.18) !important; color: #e0e7ff !important; }
+.app-sidebar .ant-menu-dark .ant-menu-submenu-title { color: #94a3b8; border-radius: 8px; margin-inline: 8px; width: calc(100% - 16px); }
+.app-sidebar .ant-menu-dark .ant-menu-submenu-title:hover { background: rgba(99,102,241,0.1) !important; color: #c7d2fe; }
+.app-sidebar .ant-layout-sider-children { display: flex; flex-direction: column; background: #07091a; }
+</style>
+
+<style scoped>
+.app-sidebar {
+  background: #07091a !important;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+@media (max-width: 767px) {
+  .app-sidebar {
+    position: fixed !important;
+    left: 0;
+    top: 0;
+    height: 100vh;
+    z-index: 200;
+  }
+}
+
+.app-sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(148, 163, 220, 0.1) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: radial-gradient(ellipse 100% 60% at 50% 0%, black 40%, transparent 100%);
+  pointer-events: none;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 20px 16px;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.brand-icon {
+  width: 32px;
+  height: 32px;
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 900;
+  font-size: 17px;
+  color: #fff;
+  flex-shrink: 0;
+  box-shadow: 0 0 16px rgba(99, 102, 241, 0.4);
+}
+
+.brand-name {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: #dde4f5;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.sidebar-nav {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 12px 0;
+}
+
+.sidebar-nav::-webkit-scrollbar { width: 4px; }
+.sidebar-nav::-webkit-scrollbar-track { background: transparent; }
+.sidebar-nav::-webkit-scrollbar-thumb { background: rgba(99, 102, 241, 0.3); border-radius: 4px; }
+
+.sidebar-menu { border-inline-end: none !important; }
+
+.sidebar-footer {
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+:deep(.logout-btn.ant-btn) {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  height: 38px;
+  border-radius: 8px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  color: #64748b !important;
+  padding: 0 12px;
+}
+
+:deep(.logout-btn.ant-btn:hover) {
+  background: rgba(239, 68, 68, 0.1) !important;
+  color: #f87171 !important;
+}
+
+.fade-label-enter-active,
+.fade-label-leave-active { transition: opacity 0.15s ease; }
+.fade-label-enter-from,
+.fade-label-leave-to { opacity: 0; }
+</style>

--- a/apps/sample-vue-full/layouts/components/AppSidebar.vue
+++ b/apps/sample-vue-full/layouts/components/AppSidebar.vue
@@ -200,7 +200,7 @@ watch(
   border-radius: 8px;
   font-family: 'DM Sans', sans-serif;
   font-size: 14px;
-  color: #64748b !important;
+  color: #94a3b8 !important;
   padding: 0 12px;
 }
 

--- a/apps/sample-vue-full/layouts/components/AppSidebar.vue
+++ b/apps/sample-vue-full/layouts/components/AppSidebar.vue
@@ -98,13 +98,13 @@ watch(
 </script>
 
 <style>
-.app-sidebar .ant-menu-dark { background: transparent; }
-.app-sidebar .ant-menu-dark.ant-menu-inline .ant-menu-sub.ant-menu-inline { background: rgba(0,0,0,0.2); }
+.app-sidebar .ant-menu-dark { background: #07091a; }
+.app-sidebar .ant-menu-dark.ant-menu-inline .ant-menu-sub.ant-menu-inline { background: #050712; }
 .app-sidebar .ant-menu-dark .ant-menu-item { color: #94a3b8; border-radius: 8px; margin-inline: 8px; width: calc(100% - 16px); }
-.app-sidebar .ant-menu-dark .ant-menu-item:hover { background: rgba(99,102,241,0.1) !important; color: #c7d2fe; }
-.app-sidebar .ant-menu-dark .ant-menu-item-selected { background: rgba(99,102,241,0.18) !important; color: #e0e7ff !important; }
+.app-sidebar .ant-menu-dark .ant-menu-item:hover { background: #13163d !important; color: #c7d2fe; }
+.app-sidebar .ant-menu-dark .ant-menu-item-selected { background: #1a1f4a !important; color: #e0e7ff !important; }
 .app-sidebar .ant-menu-dark .ant-menu-submenu-title { color: #94a3b8; border-radius: 8px; margin-inline: 8px; width: calc(100% - 16px); }
-.app-sidebar .ant-menu-dark .ant-menu-submenu-title:hover { background: rgba(99,102,241,0.1) !important; color: #c7d2fe; }
+.app-sidebar .ant-menu-dark .ant-menu-submenu-title:hover { background: #13163d !important; color: #c7d2fe; }
 .app-sidebar .ant-layout-sider-children { display: flex; flex-direction: column; background: #07091a; }
 </style>
 
@@ -205,8 +205,8 @@ watch(
 }
 
 :deep(.logout-btn.ant-btn:hover) {
-  background: rgba(239, 68, 68, 0.1) !important;
-  color: #f87171 !important;
+  background: #1e0a0a !important;
+  color: #fca5a5 !important;
 }
 
 .fade-label-enter-active,

--- a/apps/sample-vue-full/layouts/components/AppSidebar.vue
+++ b/apps/sample-vue-full/layouts/components/AppSidebar.vue
@@ -65,6 +65,7 @@
 </template>
 
 <script setup>
+// biome-ignore lint/correctness/noUnusedImports: icon used in Vue template
 import { LogoutOutlined } from '@ant-design/icons-vue';
 import { ref, watch } from 'vue';
 import { useRoute } from 'vue-router';

--- a/apps/sample-vue-full/views/Dashboard.vue
+++ b/apps/sample-vue-full/views/Dashboard.vue
@@ -1,139 +1,548 @@
 <template>
-  <div class="ds-stat-container">
-    <a-row :gutter="8">
-      <a-col class="ds-stat" :sm="24" :md="12" :xl="6">
-        <a-card>
-          <a-statistic title="Feedback" :value="11.28" :precision="2" suffix="%" :value-style="{ color: '#3f8600' }">
-            <template #prefix> <arrow-up-outlined /> </template>
-          </a-statistic>
-        </a-card>
-      </a-col>
-      <a-col class="ds-stat" :sm="24" :md="12" :xl="6">
-        <a-card>
-          <a-statistic
-            title="Idle"
-            :value="9.3"
-            :precision="2"
-            suffix="%"
-            class="demo-class"
-            :value-style="{ color: '#cf1322' }"
-          >
-            <template #prefix> <arrow-down-outlined /> </template>
-          </a-statistic>
-        </a-card>
-      </a-col>
+  <div class="dashboard">
 
-      <a-col class="ds-stat" :sm="24" :md="12" :xl="6">
-        <a-card> <a-statistic title="Active Users" :value="112893" /> </a-card>
-      </a-col>
-      <a-col class="ds-stat" :sm="24" :md="12" :xl="6">
-        <a-card> <a-statistic title="Account Balance (CNY)" :precision="2" :value="112893" /> </a-card>
+    <!-- ── Stats row ── -->
+    <a-row :gutter="[16, 16]">
+      <a-col v-for="stat in stats" :key="stat.title" :xs="24" :sm="12" :xl="6">
+        <StatCard v-bind="stat" />
       </a-col>
     </a-row>
 
-    <a-row :gutter="8">
-      <a-col class="ds-stat" :lg="24" :xl="16">
-        <a-row :gutter="8">
-          <a-col class="ds-stat" :span="12">
-            <a-page-header title="Team Members" />
-            <a-list :grid="{ gutter: 16, xs: 1, sm: 1, md: 2, lg: 3, xl: 3, xxl: 3 }" :data-source="data">
-              <template #renderItem="{ item }">
-                <a-list-item>
-                  <a-card :bordered="false">
-                    <a-avatar :size="64">
-                      <template #icon><UserOutlined /></template>
-                    </a-avatar>
-                    <a-card-meta>
-                      <template #title> <span>{{ item.name }}</span> </template>
-                      <template #description> <span style="font-size: 0.8em">{{ item.title }}</span> </template>
-                    </a-card-meta>
-                  </a-card>
-                </a-list-item>
+    <!-- ── Main content ── -->
+    <a-row :gutter="[16, 16]" style="margin-top: 16px">
+
+      <!-- Left column -->
+      <a-col :xs="24" :xl="16">
+        <a-row :gutter="[16, 16]">
+
+          <!-- Team Members -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="dash-card">
+              <template #title>
+                <div class="card-title-row">
+                  <TeamOutlined class="card-title-icon" />
+                  <span>Team Members</span>
+                  <a-badge :count="members.length" :number-style="{ background: '#4f46e5' }" />
+                </div>
               </template>
-            </a-list>
+              <template #extra>
+                <a-button type="link" size="small">View all</a-button>
+              </template>
+              <a-list :grid="{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 2, xl: 2, xxl: 3 }" :data-source="members">
+                <template #renderItem="{ item }">
+                  <a-list-item>
+                    <MemberCard
+                      :name="item.name"
+                      :role="item.role"
+                      :avatar-color="item.color"
+                      :tag-color="item.tagColor"
+                    />
+                  </a-list-item>
+                </template>
+              </a-list>
+            </a-card>
           </a-col>
-          <a-col class="ds-stat" :span="12">
-            <a-page-header title="Comments" />
-            <a-list item-layout="horizontal" :data-source="data">
-              <template #renderItem="{ item }">
-                <a-list-item>
-                  <a-list-item-meta
-                    description="Ant Design, a design language for background applications, is refined by Ant UED Team"
-                  >
-                    <template #title> <a href="https://www.antdv.com/">{{ item.title }}</a> </template>
-                    <template #avatar>
-                      <a-avatar src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png" />
+
+          <!-- Comments -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="dash-card">
+              <template #title>
+                <div class="card-title-row">
+                  <CommentOutlined class="card-title-icon" />
+                  <span>Comments</span>
+                </div>
+              </template>
+              <template #extra>
+                <a-button type="primary" size="small" ghost>
+                  <template #icon><PlusOutlined /></template>
+                  Add
+                </a-button>
+              </template>
+              <a-list item-layout="horizontal" :data-source="comments" :split="true">
+                <template #renderItem="{ item }">
+                  <a-list-item>
+                    <template #actions>
+                      <a-button type="text" size="small" @click="likeComment(item.id)">
+                        <template #icon><LikeOutlined /></template>
+                        {{ item.likes }}
+                      </a-button>
+                      <a-button type="text" size="small">
+                        <template #icon><MessageOutlined /></template>
+                        Reply
+                      </a-button>
                     </template>
-                  </a-list-item-meta>
-                </a-list-item>
-              </template>
-            </a-list>
+                    <a-list-item-meta>
+                      <template #avatar>
+                        <a-avatar :style="{ background: item.color, fontFamily: 'DM Sans, sans-serif', fontWeight: 700 }">
+                          {{ item.initials }}
+                        </a-avatar>
+                      </template>
+                      <template #title>
+                        <div class="comment-title-row">
+                          <span class="comment-author">{{ item.author }}</span>
+                          <a-tag :color="item.tagColor" style="font-size:11px">{{ item.role }}</a-tag>
+                          <span class="comment-time">{{ item.time }}</span>
+                        </div>
+                      </template>
+                      <template #description>
+                        <a-typography-paragraph :ellipsis="{ rows: 2, expandable: true, symbol: 'more' }" :content="item.content" />
+                      </template>
+                    </a-list-item-meta>
+                  </a-list-item>
+                </template>
+              </a-list>
+            </a-card>
           </a-col>
-          <a-col class="ds-stat" :span="24">
-            <a-page-header title="Something Here" />
-            <a-skeleton :paragraph="{ rows: 2 }" />
-          </a-col>
-          <a-col class="ds-stat" :span="24"></a-col>
+
         </a-row>
       </a-col>
 
-      <a-col class="ds-stat" :lg="24" :xl="8">
-        <a-row :gutter="8">
-          <a-col class="ds-stat" :span="24">
-            <a-page-header title="Useful Links" />
-            <a-skeleton :paragraph="{ rows: 3 }" />
+      <!-- Right column -->
+      <a-col :xs="24" :xl="8">
+        <a-row :gutter="[16, 16]">
+
+          <!-- Useful Links -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="dash-card">
+              <template #title>
+                <div class="card-title-row">
+                  <LinkOutlined class="card-title-icon" />
+                  <span>Useful Links</span>
+                </div>
+              </template>
+              <a-list size="small" :data-source="usefulLinks" :split="false">
+                <template #renderItem="{ item }">
+                  <a-list-item class="link-item">
+                    <div class="link-icon-wrap" :style="{ background: item.bg }">
+                      <component :is="item.icon" :style="{ color: item.color }" />
+                    </div>
+                    <div class="link-body">
+                      <a :href="item.url" target="_blank" rel="noopener" class="link-title">
+                        {{ item.title }}
+                      </a>
+                      <span class="link-desc">{{ item.desc }}</span>
+                    </div>
+                    <LinkOutlined class="link-arrow" />
+                  </a-list-item>
+                </template>
+              </a-list>
+            </a-card>
           </a-col>
-          <a-col class="ds-stat" :span="24">
-            <a-page-header title="Useful Links 2" />
-            <a-skeleton :paragraph="{ rows: 15 }" />
+
+          <!-- Announcements -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="dash-card">
+              <template #title>
+                <div class="card-title-row">
+                  <NotificationOutlined class="card-title-icon" />
+                  <span>Announcements</span>
+                  <a-badge :count="announcements.filter(a => !a.read).length" :number-style="{ background: '#4f46e5' }" />
+                </div>
+              </template>
+              <a-timeline class="announcement-timeline">
+                <a-timeline-item
+                  v-for="item in announcements"
+                  :key="item.id"
+                  :color="item.color"
+                >
+                  <div class="announcement-item" :class="{ 'announcement-item--unread': !item.read }">
+                    <div class="announcement-head">
+                      <a-tag :color="item.tagColor" style="font-size:11px;margin:0">{{ item.type }}</a-tag>
+                      <span class="announcement-time">{{ item.time }}</span>
+                    </div>
+                    <p class="announcement-title">{{ item.title }}</p>
+                    <p class="announcement-body">{{ item.body }}</p>
+                  </div>
+                </a-timeline-item>
+              </a-timeline>
+            </a-card>
           </a-col>
+
         </a-row>
       </a-col>
+
     </a-row>
   </div>
-  <!--
-    <a-row :gutter="8">
-      <a-col class="ds-stat" :xs="24" :sm="12" :md="8" :lg="6">
-        <a-statistic title="Feedback" :value="1128" style="margin-right: 50px">
-          <template #suffix><like-outlined /></template>
-        </a-statistic>
-      </a-col>
-      <a-col class="ds-stat" :xs="24" :sm="12" :md="8" :lg="6">
-        <a-statistic title="Unmerged" :value="93" class="demo-class">
-          <template #suffix><span>/ 100</span></template>
-        </a-statistic>
-      </a-col>
-    </a-row>
-  -->
 </template>
 
 <script setup>
-const data = [
-  { name: 'Faith', title: 'Full-stack Dev' },
-  { name: 'Hope', title: 'Data Scientist' },
-  { name: 'Charity', title: 'Data Engineer' },
-  { name: 'Love', title: 'Data Scientist' },
+import {
+  BookOutlined,
+  BugOutlined,
+  CodeOutlined,
+  CommentOutlined,
+  DollarOutlined,
+  FileTextOutlined,
+  GithubOutlined,
+  LikeOutlined,
+  LinkOutlined,
+  MessageOutlined,
+  NotificationOutlined,
+  PlusOutlined,
+  RiseOutlined,
+  TeamOutlined,
+  ThunderboltOutlined,
+  UserOutlined,
+} from '@ant-design/icons-vue';
+import { ref } from 'vue';
+import MemberCard from '../components/MemberCard.vue';
+import StatCard from '../components/StatCard.vue';
+
+/* ── Stats ── */
+const stats = [
+  {
+    title: 'Feedback',
+    value: 11.28,
+    precision: 2,
+    suffix: '%',
+    trend: 'up',
+    footer: '+4.6% from last month',
+    icon: RiseOutlined,
+    iconBg: '#dcfce7',
+  },
+  {
+    title: 'Idle',
+    value: 9.3,
+    precision: 2,
+    suffix: '%',
+    trend: 'down',
+    footer: '-1.2% from last month',
+    icon: ThunderboltOutlined,
+    iconBg: '#fee2e2',
+  },
+  {
+    title: 'Active Users',
+    value: 112893,
+    trend: null,
+    footer: '+2,340 this week',
+    icon: UserOutlined,
+    iconBg: '#eef2ff',
+  },
+  {
+    title: 'Account Balance (CNY)',
+    value: 112893,
+    precision: 2,
+    trend: null,
+    footer: 'Updated just now',
+    icon: DollarOutlined,
+    iconBg: '#fef9c3',
+  },
 ];
+
+/* ── Team members ── */
+const members = [
+  { name: 'Faith Tan', role: 'Full-stack Dev', color: '#4f46e5', tagColor: 'purple' },
+  { name: 'Hope Lee', role: 'Data Scientist', color: '#0ea5e9', tagColor: 'blue' },
+  { name: 'Charity Wong', role: 'Data Engineer', color: '#10b981', tagColor: 'green' },
+  { name: 'Love Chen', role: 'Data Scientist', color: '#f59e0b', tagColor: 'gold' },
+];
+
+/* ── Comments ── */
+const comments = ref([
+  {
+    id: 1,
+    author: 'Faith Tan',
+    initials: 'FT',
+    role: 'Full-stack Dev',
+    color: '#4f46e5',
+    tagColor: 'purple',
+    content:
+      'The new dashboard layout looks great! Really improves the data visibility for the team. Can we also add a date range filter?',
+    time: '2 hours ago',
+    likes: 5,
+  },
+  {
+    id: 2,
+    author: 'Hope Lee',
+    initials: 'HL',
+    role: 'Data Scientist',
+    color: '#0ea5e9',
+    tagColor: 'blue',
+    content:
+      'Agreed. The stat cards are much cleaner now. I think we should consider adding sparkline charts inside each card to show the trend over time.',
+    time: '1 hour ago',
+    likes: 3,
+  },
+  {
+    id: 3,
+    author: 'Charity Wong',
+    initials: 'CW',
+    role: 'Data Engineer',
+    color: '#10b981',
+    tagColor: 'green',
+    content:
+      'Pipeline ran successfully overnight. All 14 jobs completed without errors. Data is fresh as of 06:00 UTC.',
+    time: '30 min ago',
+    likes: 7,
+  },
+]);
+
+const likeComment = id => {
+  const c = comments.value.find(c => c.id === id);
+  if (c) c.likes++;
+};
+
+/* ── Useful Links ── */
+const usefulLinks = [
+  {
+    title: 'Documentation',
+    desc: 'Project docs and API reference',
+    url: '#',
+    icon: BookOutlined,
+    color: '#4f46e5',
+    bg: '#eef2ff',
+  },
+  {
+    title: 'GitHub Repo',
+    desc: 'Source code and pull requests',
+    url: '#',
+    icon: GithubOutlined,
+    color: '#0f172a',
+    bg: '#f1f5f9',
+  },
+  {
+    title: 'API Playground',
+    desc: 'Test endpoints interactively',
+    url: '#',
+    icon: CodeOutlined,
+    color: '#0ea5e9',
+    bg: '#e0f2fe',
+  },
+  {
+    title: 'Release Notes',
+    desc: 'Changelog and version history',
+    url: '#',
+    icon: FileTextOutlined,
+    color: '#10b981',
+    bg: '#dcfce7',
+  },
+  {
+    title: 'Bug Tracker',
+    desc: 'Report and track issues',
+    url: '#',
+    icon: BugOutlined,
+    color: '#ef4444',
+    bg: '#fee2e2',
+  },
+];
+
+/* ── Announcements ── */
+const announcements = ref([
+  {
+    id: 1,
+    type: 'Release',
+    tagColor: 'purple',
+    color: '#4f46e5',
+    title: 'v0.7.0 released',
+    body: 'New sidebar layout, reusable StatCard and MemberCard components, and ADV-based header with notifications and chat.',
+    time: '2 hours ago',
+    read: false,
+  },
+  {
+    id: 2,
+    type: 'Maintenance',
+    tagColor: 'orange',
+    color: '#f59e0b',
+    title: 'Scheduled downtime — 22 May 02:00 UTC',
+    body: 'Database migration for the audit log table. Expected duration: 15 minutes. No data loss expected.',
+    time: 'Yesterday',
+    read: false,
+  },
+  {
+    id: 3,
+    type: 'Update',
+    tagColor: 'blue',
+    color: '#0ea5e9',
+    title: 'CDN dependencies updated',
+    body: 'Vue upgraded to 3.5.34, vue-router to 4.6.4, Bulma to 0.9.4. SRI hashes refreshed across all CDN links.',
+    time: '3 days ago',
+    read: true,
+  },
+  {
+    id: 4,
+    type: 'Security',
+    tagColor: 'red',
+    color: '#ef4444',
+    title: 'SRI enforcement enabled',
+    body: 'All external CDN resources now require Subresource Integrity attributes. Review your custom scripts if any.',
+    time: '1 week ago',
+    read: true,
+  },
+]);
 </script>
 
-<style>
-.ds-stat {
-  margin-top: 0px;
-  padding-top: 0px;
-  /* background-color: lightslategray; */
+<style scoped>
+.dashboard {
+  font-family: 'DM Sans', sans-serif;
 }
 
-.ds-stat-container {
-  /* background: #ececec; */
+:deep(.dash-card) {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.dash-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.dash-card .ant-card-head-title) {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  padding: 12px 0;
+}
+
+:deep(.dash-card .ant-card-body) {
+  padding: 16px 20px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+.comment-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.comment-author {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.comment-time {
+  font-size: 12px;
+  color: #94a3b8;
+  margin-left: auto;
+}
+
+:deep(.ant-list-item-action li) {
   padding: 0;
 }
 
-.ant-card-meta-title {
-  margin-bottom: 0;
+/* ── Useful Links ── */
+:deep(.link-item.ant-list-item) {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s;
 }
 
-.ant-card-body {
-  /* justify-content: center !important; */
-  text-align: center;
+:deep(.link-item.ant-list-item:hover) {
+  background: #f8fafc;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.link-icon-wrap {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.link-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.link-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.link-title:hover {
+  color: #4f46e5;
+}
+
+.link-desc {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.link-arrow {
+  color: #cbd5e1;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* ── Announcements ── */
+.announcement-timeline {
+  padding-top: 4px;
+}
+
+:deep(.announcement-timeline.ant-timeline) {
+  margin-bottom: -24px;
+}
+
+.announcement-item {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid #f1f5f9;
+  transition: border-color 0.15s;
+}
+
+.announcement-item--unread {
+  background: #fafafe;
+  border-color: #e0e7ff;
+}
+
+.announcement-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.announcement-time {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  color: #94a3b8;
+}
+
+.announcement-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 4px;
+}
+
+.announcement-body {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.5;
 }
 </style>

--- a/apps/sample-vue-full/views/Dashboard.vue
+++ b/apps/sample-vue-full/views/Dashboard.vue
@@ -20,7 +20,7 @@
             <a-card :bordered="false" class="dash-card">
               <template #title>
                 <div class="card-title-row">
-                  <TeamOutlined class="card-title-icon" />
+                  <component :is="templateIcons.TeamOutlined" class="card-title-icon" />
                   <span>Team Members</span>
                   <a-badge :count="members.length" :number-style="{ background: '#4f46e5' }" />
                 </div>
@@ -48,13 +48,13 @@
             <a-card :bordered="false" class="dash-card">
               <template #title>
                 <div class="card-title-row">
-                  <CommentOutlined class="card-title-icon" />
+                  <component :is="templateIcons.CommentOutlined" class="card-title-icon" />
                   <span>Comments</span>
                 </div>
               </template>
               <template #extra>
                 <a-button type="primary" size="small" ghost>
-                  <template #icon><PlusOutlined /></template>
+                  <template #icon><component :is="templateIcons.PlusOutlined" /></template>
                   Add
                 </a-button>
               </template>
@@ -63,11 +63,11 @@
                   <a-list-item>
                     <template #actions>
                       <a-button type="text" size="small" @click="likeComment(item.id)">
-                        <template #icon><LikeOutlined /></template>
+                        <template #icon><component :is="templateIcons.LikeOutlined" /></template>
                         {{ item.likes }}
                       </a-button>
                       <a-button type="text" size="small">
-                        <template #icon><MessageOutlined /></template>
+                        <template #icon><component :is="templateIcons.MessageOutlined" /></template>
                         Reply
                       </a-button>
                     </template>
@@ -106,7 +106,7 @@
             <a-card :bordered="false" class="dash-card">
               <template #title>
                 <div class="card-title-row">
-                  <LinkOutlined class="card-title-icon" />
+                  <component :is="templateIcons.LinkOutlined" class="card-title-icon" />
                   <span>Useful Links</span>
                 </div>
               </template>
@@ -122,7 +122,7 @@
                       </a>
                       <span class="link-desc">{{ item.desc }}</span>
                     </div>
-                    <LinkOutlined class="link-arrow" />
+                    <component :is="templateIcons.LinkOutlined" class="link-arrow" />
                   </a-list-item>
                 </template>
               </a-list>
@@ -134,7 +134,7 @@
             <a-card :bordered="false" class="dash-card">
               <template #title>
                 <div class="card-title-row">
-                  <NotificationOutlined class="card-title-icon" />
+                  <component :is="templateIcons.NotificationOutlined" class="card-title-icon" />
                   <span>Announcements</span>
                   <a-badge :count="announcements.filter(a => !a.read).length" :number-style="{ background: '#4f46e5' }" />
                 </div>
@@ -166,6 +166,7 @@
 </template>
 
 <script setup>
+/* ── Icon refs used in template (explicit for Biome) ── */
 import {
   BookOutlined,
   BugOutlined,
@@ -184,9 +185,21 @@ import {
   ThunderboltOutlined,
   UserOutlined,
 } from '@ant-design/icons-vue';
-import { ref } from 'vue';
+import { markRaw, ref } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
 import MemberCard from '../components/MemberCard.vue';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
 import StatCard from '../components/StatCard.vue';
+
+const templateIcons = markRaw({
+  CommentOutlined,
+  LikeOutlined,
+  LinkOutlined,
+  MessageOutlined,
+  NotificationOutlined,
+  PlusOutlined,
+  TeamOutlined,
+});
 
 /* ── Stats ── */
 const stats = [

--- a/apps/sample-vue-full/views/SignIn.vue
+++ b/apps/sample-vue-full/views/SignIn.vue
@@ -393,7 +393,7 @@ const oauthLogin = () => {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: 'DM Sans', sans-serif;
   font-weight: 900;
   font-size: 20px;
   color: #fff;
@@ -401,7 +401,7 @@ const oauthLogin = () => {
 }
 
 .brand-wordmark {
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: 'DM Sans', sans-serif;
   font-size: 21px;
   font-weight: 700;
   color: #dde4f5;
@@ -426,7 +426,7 @@ const oauthLogin = () => {
 }
 
 .pitch-heading {
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: 'DM Sans', sans-serif;
   font-size: clamp(40px, 4.8vw, 70px);
   font-weight: 900;
   line-height: 1.04;
@@ -509,7 +509,7 @@ const oauthLogin = () => {
 }
 
 .form-head h1 {
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: 'DM Sans', sans-serif;
   font-size: 30px;
   font-weight: 700;
   color: var(--slate-900);


### PR DESCRIPTION
## Pull Request Checklist

- [ ] I read and followed the [Contribution guide](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)
- [ ] I linked the related issue, if one exists
- [x] I ran the relevant checks or tests for the affected area

## Summary

Redesign the `sample-vue-full` secure layout and dashboard with reusable components, proper Ant Design Vue usage throughout, and a consistent DM Sans typography system. Also fixes Biome false-positive `noUnusedImports` warnings caused by Vue template imports not being detectable by Biome's JS/TS AST analysis.

**Secure layout split into three reusable components:**

- `AppSidebar.vue` — dark navy sidebar with indigo accent, collapsible with `breakpoint="md"`, brand icon/name via props, route-driven `a-menu`, logout button. Mobile: `position: fixed` with backdrop overlay.
- `AppHeader.vue` — sticky white header with toggle button, breadcrumb, search input (toggle on click), chat popover, notification popover, vertical divider, user avatar dropdown. All data (notifications, messages) received via props; mutations emitted as events (`notif-read`, `notif-read-all`, `message-read`, `message-read-all`).
- `AppFooter.vue` — minimal footer with `brand` prop.

All three components are fully prop-driven with no hardcoded app-specific data, making them reusable across other apps in the monorepo.

**Dashboard redesign using ADV components:**

- **Stats row** — four `StatCard` reusable components wrapping `a-statistic` inside `a-card`, with `trend`, `icon`, `footer`, and `iconBg` props. Hover lift animation via CSS transition.
- **Team Members** — `MemberCard` reusable component using `a-card` + `a-avatar` + `a-tag`. Props: `name`, `role`, `avatarColor`, `tagColor`. Visible border + shadow on hover.
- **Comments** — `a-list` + `a-list-item-meta` + `a-avatar` + `a-typography-paragraph` (with expandable ellipsis) + `a-button` like/reply actions.
- **Useful Links** — `a-list` with icon, title, description, and arrow per item.
- **Announcements** — `a-timeline` with type tag, unread badge, and read/unread visual distinction.

**Other changes:**

- Replaced all `Fraunces` serif font references with `DM Sans` for a consistent, modern UI.
- Fixed Biome `noUnusedImports` false positives: icon imports used only in Vue templates are refactored into `computed` refs or `markRaw` objects so Biome can detect them in script; remaining unavoidable cases use inline `biome-ignore` directives.

## Affected Area

- [x] apps
- [ ] common
- [ ] docs
- [ ] scripts
- [ ] CI/CD or GitHub Actions

## Validation

```text
# Biome check — 0 errors, 0 warnings
npx biome check apps/sample-vue-full

# Manual — open http://127.0.0.1:8080
# 1. Login with "Force login (bypass backend)" checkbox
# 2. Verify sidebar collapses on mobile (< 768px)
# 3. Verify notification and chat popovers open/close correctly
# 4. Verify stat card hover animation
# 5. Verify team member cards show border and shadow
