### PR TITLE
chore(common): move safeReplacer to common/iso specifically in util.js

### DIFF
--- a/common/compiled/node/logger.ts
+++ b/common/compiled/node/logger.ts
@@ -1,20 +1,9 @@
+import { safeReplacer } from '@common/iso/util';
 import type { NextFunction, Request, Response } from 'express';
 
 const LOG_LEVELS: Record<string, number> = { error: 0, warn: 1, info: 2, debug: 3 };
 const currentLevel = LOG_LEVELS[process.env.LOG_LEVEL ?? ''] ?? LOG_LEVELS.info;
 const { npm_package_name, npm_package_version } = process.env;
-
-/** JSON.stringify replacer that replaces circular references with '[Circular]'. */
-function safeReplacer() {
-  const seen = new WeakSet();
-  return (_key: string, value: unknown) => {
-    if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) return '[Circular]';
-      seen.add(value);
-    }
-    return value;
-  };
-}
 
 const log = (level: string, message: unknown, meta: Record<string, unknown> = {}) => {
   if (LOG_LEVELS[level] > currentLevel) return;

--- a/common/compiled/node/package.json
+++ b/common/compiled/node/package.json
@@ -31,6 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@common/iso": "file:../../vanilla/iso",
     "@aws-sdk/client-s3": "^3.1041.0",
     "@aws-sdk/s3-request-presigner": "^3.1041.0",
     "@node-saml/node-saml": "^5.1.0",

--- a/common/vanilla/iso/util.js
+++ b/common/vanilla/iso/util.js
@@ -15,3 +15,19 @@ export const isValidObject = value => value && typeof value === 'object' && valu
 
 /** @deprecated Use `isEmptyObject` instead. */
 export const emptyObjects = isEmptyObject;
+
+/**
+ * JSON.stringify replacer that handles circular references.
+ * Returns '[Circular]' for any object already seen in the current serialisation.
+ * @returns {(_key: string, value: unknown) => unknown}
+ */
+export function safeReplacer() {
+  const seen = new WeakSet();
+  return (_key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return '[Circular]';
+      seen.add(value);
+    }
+    return value;
+  };
+}


### PR DESCRIPTION
## Pull Request Checklist

* [x] I read and followed the [[Contribution guide](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)
* [x] I linked the related issue, if one exists https://github.com/ais-one/novex-kit/issues/391
* [x] I ran the relevant checks or tests for the affected area

## Summary

Moves `safeReplacer` into `common/vanilla/iso/util.js` so it can be reused across shared/common modules from a centralized location.

This helps reduce duplication and improves consistency for serialization utilities used across the repository.

## Affected Area

* [ ] apps
* [x] common
* [ ] docs
* [ ] scripts
* [ ] CI/CD or GitHub Actions

## Validation

```text
- Verified imports/usages after moving the utility
- Confirmed existing serialization behavior remains unchanged
- Confirmed no platform-specific dependency exists in the moved utility
```

## Notes

This is intended as a refactor-only change with no expected runtime behavior changes.