### PR TITLE
feat(common): implement multiple senders for comms modules

### DIFF
--- a/apps/sample-api/.env.local
+++ b/apps/sample-api/.env.local
@@ -10,58 +10,18 @@ API_PORT=3000
 
 PYTHON_BIN=/usr/bin/python3
 
-# ─── SendGrid Email ──────────────────────────────────────────────────────────
-# Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
+# ─── Multi-Tenant Communications ─────────────────────────────────────────────
+# Master password used to encrypt/decrypt tenant communication credentials at rest.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# COMMS_ENCRYPTION_KEY=
 
-# API key for authentication
-# Get from: SendGrid Dashboard → Settings → API Keys → Create API Key
-#           Permissions needed: Mail Send (Full Access), Template Engine (Full Access)
-# SENDGRID_KEY=
-
-# Display name shown in the From field
-# SENDGRID_SENDER_NAME=
-
-# From email address — must be verified via Single Sender or Domain Authentication
-# Get from: SendGrid Dashboard → Settings → Sender Authentication
-# SENDGRID_SENDER_EMAIL=
-
-# Default dynamic template ID used by the v1 sendDynamicEmail helper
-# Get from: SendGrid Dashboard → Email API → Dynamic Templates
-# Prefix is always d-
-# SENDGRID_TEMPLATE_ID=
-
-# Set to 'true' to log every SendGrid request and response body (dev only)
-# Requires LOG_LEVEL=debug to be visible in structured logs
-# SENDGRID_DEBUG=
-
-# ─── WhatsApp Cloud API ───────────────────────────────────────────────────────
-# Docs: https://developers.facebook.com/documentation/business-messaging/whatsapp/get-started
-
-# Permanent system user access token
-# Get from: Meta Business Settings (business.facebook.com/latest/settings)
-#           → System Users → [your system user] → Generate token
-#           Permissions needed: business_management, whatsapp_business_messaging, whatsapp_business_management
-# WHATSAPP_TOKEN=
-
-# Phone number ID (not the phone number itself — it's a numeric ID)
-# Get from: Meta App Dashboard → WhatsApp → API Setup → "From" phone number section
-# WHATSAPP_PHONE_NUMBER_ID=
-
-# WhatsApp Business Account ID
-# Get from: Meta App Dashboard → WhatsApp → API Setup (shown after connecting a business account)
-# WHATSAPP_BUSINESS_ACCOUNT_ID=
-
-# Your own secret string — used once during webhook registration to verify your endpoint
-# Get from: you choose this yourself — any random string (e.g. "my_verify_secret_2024")
-#           Enter the same value in Meta App Dashboard → WhatsApp → Configuration → Webhook → Verify Token
-# WHATSAPP_VERIFY_TOKEN=
-
-# Set to 'true' to print every WhatsApp API request + response to the Node console (dev only)
-# Requires LOG_LEVEL=debug to be visible in the structured logs
+# ─── Debug Flags (not per-tenant) ────────────────────────────────────────────
+# SENDGRID_DEBUG=true
 # WA_DEBUG=true
 # LOG_LEVEL=debug
 
-# App Secret — used to verify the X-Hub-Signature-256 header on inbound webhooks
-# Get from: Meta App Dashboard → App Settings → Basic → App Secret
-# Leave unset to skip verification (OK for local dev, required for production)
+# ─── WhatsApp Webhook (system-level, not per-tenant) ─────────────────────────
+# These are needed for webhook registration and signature verification.
+# They belong to the Meta App itself, not to individual tenants.
+# WHATSAPP_VERIFY_TOKEN=
 # WHATSAPP_APP_SECRET=

--- a/apps/sample-api/.gitignore
+++ b/apps/sample-api/.gitignore
@@ -49,11 +49,13 @@ src/*/routes.ts
 !src/sendgrid/template-routes.ts
 !src/sendgrid/webhook-routes.ts
 !src/sse/routes.ts
+!src/telegram/routes.ts
 !src/tenant-comms/routes.ts
 !src/tests/routes.ts
 !src/webhooks/routes.ts
 !src/webpush/routes.ts
 !src/whatsapp/routes.ts
+!src/whatsapp/template-routes.ts
 
 # webpush has a hand-written schema that would otherwise be gitignored
 !src/webpush/schema.js

--- a/apps/sample-api/.gitignore
+++ b/apps/sample-api/.gitignore
@@ -49,6 +49,7 @@ src/*/routes.ts
 !src/sendgrid/template-routes.ts
 !src/sendgrid/webhook-routes.ts
 !src/sse/routes.ts
+!src/tenant-comms/routes.ts
 !src/tests/routes.ts
 !src/webhooks/routes.ts
 !src/webpush/routes.ts

--- a/apps/sample-api/src/app.ts
+++ b/apps/sample-api/src/app.ts
@@ -1,25 +1,38 @@
 import * as rbac from '@common/node/auth/rbac';
 import * as store from '@common/node/auth/store';
+import * as commsTenant from '@common/node/comms/tenant/resolver';
 import * as dbAudit from '@common/node/db-audit';
 import postRoute from '@common/node/express/postRoute';
 import preRoute from '@common/node/express/preRoute';
 import * as services from '@common/node/services';
 import { users } from './database/schema.ts';
 import { hardDeleteLog } from './database/schema-audit.ts';
-import { permissions, rolePermissions, tenantRoles, tenants, userTenantRoles } from './database/schema-iam.ts';
+import {
+  permissions,
+  rolePermissions,
+  tenantCommsConfig,
+  tenantRoles,
+  tenants,
+  userTenantRoles,
+} from './database/schema-iam.ts';
 import apiRoutes from './router.ts';
 
 store.configure({ users });
 rbac.configure({ permissions, rolePermissions, tenantRoles, tenants, userTenantRoles });
 dbAudit.configure({ hardDeleteLog });
+commsTenant.configure({ tenantCommsConfig });
 
 logger.info(`Starting...`);
 const { app, express, server } = preRoute();
 await services.start(app, server);
 
+commsTenant.setup('drizzle1', services.get);
+
 if (!store.isConfigured()) throw new Error('store.configure() was not called — users table missing');
 if (!rbac.isConfigured()) throw new Error('rbac.configure() was not called — IAM tables missing');
 if (!dbAudit.isConfigured()) throw new Error('dbAudit.configure() was not called — hardDeleteLog table missing');
+if (!commsTenant.isConfigured())
+  throw new Error('commsTenant.configure()/setup() was not called — tenant comms config missing');
 
 apiRoutes({ app }); // TODO route prefix & versioning
 postRoute(app, express);

--- a/apps/sample-api/src/app.ts
+++ b/apps/sample-api/src/app.ts
@@ -1,6 +1,6 @@
 import * as rbac from '@common/node/auth/rbac';
 import * as store from '@common/node/auth/store';
-import * as commsTenant from '@common/node/comms/tenant/resolver';
+import { init as initComms } from '@common/node/comms/service/send';
 import * as dbAudit from '@common/node/db-audit';
 import postRoute from '@common/node/express/postRoute';
 import preRoute from '@common/node/express/preRoute';
@@ -20,19 +20,16 @@ import apiRoutes from './router.ts';
 store.configure({ users });
 rbac.configure({ permissions, rolePermissions, tenantRoles, tenants, userTenantRoles });
 dbAudit.configure({ hardDeleteLog });
-commsTenant.configure({ tenantCommsConfig });
 
 logger.info(`Starting...`);
 const { app, express, server } = preRoute();
 await services.start(app, server);
 
-commsTenant.setup('drizzle1', services.get);
+initComms({ table: tenantCommsConfig, serviceName: 'drizzle1', lookup: services.get });
 
 if (!store.isConfigured()) throw new Error('store.configure() was not called — users table missing');
 if (!rbac.isConfigured()) throw new Error('rbac.configure() was not called — IAM tables missing');
 if (!dbAudit.isConfigured()) throw new Error('dbAudit.configure() was not called — hardDeleteLog table missing');
-if (!commsTenant.isConfigured())
-  throw new Error('commsTenant.configure()/setup() was not called — tenant comms config missing');
 
 apiRoutes({ app }); // TODO route prefix & versioning
 postRoute(app, express);

--- a/apps/sample-api/src/database/schema-iam.ts
+++ b/apps/sample-api/src/database/schema-iam.ts
@@ -351,6 +351,7 @@ export const tenantCommsConfig = iamSchema.table(
     tenant_id: integer('tenant_id')
       .notNull()
       .references(() => tenants.id, { onDelete: 'cascade' }),
+    label: varchar('label', { length: 100 }).notNull(),
     channel: varchar('channel', { length: 50 }).notNull(),
     provider: varchar('provider', { length: 50 }).notNull(),
     credentials: text('credentials').notNull(),
@@ -359,5 +360,5 @@ export const tenantCommsConfig = iamSchema.table(
     created_at: timestamp('created_at', { withTimezone: true }).notNull().default(sql`now()`),
     updated_at: timestamp('updated_at', { withTimezone: true }).notNull().default(sql`now()`),
   },
-  t => [unique().on(t.tenant_id, t.channel, t.provider)],
+  t => [unique().on(t.tenant_id, t.channel, t.label)],
 );

--- a/apps/sample-api/src/database/schema-iam.ts
+++ b/apps/sample-api/src/database/schema-iam.ts
@@ -5,6 +5,7 @@ import {
   index,
   integer,
   json,
+  jsonb,
   pgSchema,
   primaryKey,
   serial,
@@ -339,4 +340,24 @@ export const userTenantRoles = iamSchema.table(
     primaryKey({ columns: [t.user_id, t.tenant_id, t.role_id] }),
     index('idx_user_tenant_roles_lookup').on(t.user_id, t.tenant_id),
   ],
+);
+
+// ─── tenant_comms_config ──────────────────────────────────────────────────────
+
+export const tenantCommsConfig = iamSchema.table(
+  'tenant_comms_config',
+  {
+    id: serial('id').primaryKey(),
+    tenant_id: integer('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    channel: varchar('channel', { length: 50 }).notNull(),
+    provider: varchar('provider', { length: 50 }).notNull(),
+    credentials: text('credentials').notNull(),
+    sender_identity: jsonb('sender_identity').notNull().default({}),
+    is_active: boolean('is_active').notNull().default(true),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull().default(sql`now()`),
+    updated_at: timestamp('updated_at', { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  t => [unique().on(t.tenant_id, t.channel, t.provider)],
 );

--- a/apps/sample-api/src/router.ts
+++ b/apps/sample-api/src/router.ts
@@ -10,6 +10,7 @@ import email from './sendgrid/routes.ts';
 import emailTemplates from './sendgrid/template-routes.ts';
 import emailWebhooks from './sendgrid/webhook-routes.ts';
 import sse from './sse/routes.ts';
+import telegram from './telegram/routes.ts';
 import tenantComms from './tenant-comms/routes.ts';
 import tests from './tests/routes.ts';
 import webhooks from './webhooks/routes.ts';
@@ -38,6 +39,7 @@ export default ({ app }) => {
     router.use('/sendgrid', email), // http://127.0.0.1:3000/api/sample-api/sendgrid/test
     router.use('/sendgrid/templates', emailTemplates), // http://127.0.0.1:3000/api/sample-api/sendgrid/templates
     router.use('/sendgrid', emailWebhooks), // http://127.0.0.1:3000/api/sample-api/sendgrid/inbound + /events
+    router.use('/telegram', telegram), // http://127.0.0.1:3000/api/sample-api/telegram/test + /send + /webhook
     router.use('/tenant-comms', tenantComms), // http://127.0.0.1:3000/api/sample-api/tenant-comms
     router.use('/sse', sse),
     router.use('/tests', tests), // for tests

--- a/apps/sample-api/src/router.ts
+++ b/apps/sample-api/src/router.ts
@@ -10,6 +10,7 @@ import email from './sendgrid/routes.ts';
 import emailTemplates from './sendgrid/template-routes.ts';
 import emailWebhooks from './sendgrid/webhook-routes.ts';
 import sse from './sse/routes.ts';
+import tenantComms from './tenant-comms/routes.ts';
 import tests from './tests/routes.ts';
 import webhooks from './webhooks/routes.ts';
 import webpush from './webpush/routes.ts';
@@ -37,6 +38,7 @@ export default ({ app }) => {
     router.use('/sendgrid', email), // http://127.0.0.1:3000/api/sample-api/sendgrid/test
     router.use('/sendgrid/templates', emailTemplates), // http://127.0.0.1:3000/api/sample-api/sendgrid/templates
     router.use('/sendgrid', emailWebhooks), // http://127.0.0.1:3000/api/sample-api/sendgrid/inbound + /events
+    router.use('/tenant-comms', tenantComms), // http://127.0.0.1:3000/api/sample-api/tenant-comms
     router.use('/sse', sse),
     router.use('/tests', tests), // for tests
     router.use('/webpush', webpush),

--- a/apps/sample-api/src/sendgrid/routes.ts
+++ b/apps/sample-api/src/sendgrid/routes.ts
@@ -1,13 +1,7 @@
-import {
-  cancelScheduledEmail,
-  sendBulkDynamicEmail,
-  sendBulkEmail,
-  sendDynamicEmail,
-  sendEmail,
-  sendEmailWithAttachments,
-  sendScheduledEmail,
-} from '@common/node/comms/sendgrid/outbound';
+import { cancelScheduledEmail, sendBulkDynamicEmail, sendBulkEmail } from '@common/node/comms/sendgrid/outbound';
 import type { SendGridAuth, SgAttachment, SgPersonalization, SgSendEmailOpts } from '@common/node/comms/sendgrid/types';
+import { broadcast } from '@common/node/comms/service/broadcast';
+import { send } from '@common/node/comms/service/send';
 import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import type { Request, Response } from 'express';
 import express from 'express';
@@ -15,8 +9,11 @@ import express from 'express';
 // SendGrid email test dispatcher
 // Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
 //
-// Credentials are resolved per-tenant from the database via resolveCommsCredentials().
+// Credentials are resolved per-tenant from the database via the unified comms service.
 // Each tenant must configure their own SendGrid API key and sender identity.
+
+// ─── Types supported by the unified send() ────────────────────────────────────
+const UNIFIED_TYPES = new Set(['html', 'dynamic', 'attachment', 'scheduled', 'scheduled_dynamic']);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -40,46 +37,7 @@ function buildOpts(
   return opts;
 }
 
-// ─── Type handlers ────────────────────────────────────────────────────────────
-
-async function handleHtml(
-  auth: SendGridAuth,
-  dest: string | string[],
-  p: Record<string, unknown>,
-  tenantContext?: { _tenantId: number; _configLabel: string },
-) {
-  const opts = buildOpts(p, tenantContext);
-  return sendEmail(auth, dest, String(p.subject ?? 'Test Email'), String(p.html ?? ''), opts);
-}
-
-async function handleDynamic(
-  auth: SendGridAuth,
-  dest: string | string[],
-  p: Record<string, unknown>,
-  tenantContext?: { _tenantId: number; _configLabel: string },
-) {
-  const opts = buildOpts(p, tenantContext);
-  return sendDynamicEmail(auth, dest, String(p.templateId ?? ''), (p.data as Record<string, unknown>) ?? {}, opts);
-}
-
-async function handleAttachment(
-  auth: SendGridAuth,
-  dest: string | string[],
-  p: Record<string, unknown>,
-  tenantContext?: { _tenantId: number; _configLabel: string },
-) {
-  const opts = buildOpts(p, tenantContext);
-  // attachments are passed as both the required param and in opts (sendEmailWithAttachments merges them)
-  delete opts.attachments;
-  return sendEmailWithAttachments(
-    auth,
-    dest,
-    String(p.subject ?? 'Test Email'),
-    String(p.html ?? ''),
-    (p.attachments as SgAttachment[]) ?? [],
-    opts,
-  );
-}
+// ─── Non-unified type handlers (bulk, cancel — different input shapes) ────────
 
 async function handleBulk(
   auth: SendGridAuth,
@@ -110,22 +68,6 @@ async function handleBulkDynamic(
   );
 }
 
-async function handleScheduled(
-  auth: SendGridAuth,
-  dest: string | string[],
-  p: Record<string, unknown>,
-  res: Response,
-  tenantContext?: { _tenantId: number; _configLabel: string },
-) {
-  const sendAt = Number(p.sendAt);
-  if (!sendAt || Number.isNaN(sendAt)) {
-    res.status(400).json({ ok: false, error: 'sendAt (unix timestamp) is required for scheduled type' });
-    return null;
-  }
-  const opts = buildOpts(p, tenantContext);
-  return sendScheduledEmail(auth, dest, String(p.subject ?? 'Scheduled Email'), String(p.html ?? ''), sendAt, opts);
-}
-
 async function handleCancel(auth: SendGridAuth, p: Record<string, unknown>, res: Response) {
   if (!p.batchId) {
     res.status(400).json({ ok: false, error: 'batchId is required for cancel type' });
@@ -141,9 +83,8 @@ export default express
 
   // ── POST /api/sample-api/sendgrid/test ────────────────────────────────────────
   // Multi-type test dispatcher.
-  // Body: { type, to, ...type-specific fields }
-  // Requires authenticated user with tenant_id for credential resolution.
-  // See EmailTest.vue for sample payloads per type.
+  // Body: { type, to, configLabel?, ...type-specific fields }
+  // Types in the unified service go through send(). Others use direct library calls.
   .post('/test', async (req: Request, res: Response) => {
     const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
     if (!tenantId) {
@@ -151,74 +92,113 @@ export default express
       return;
     }
 
-    const { configLabel } = req.body as { configLabel?: string };
-
-    let auth: SendGridAuth;
-    let tenantContext: { _tenantId: number; _configLabel: string } | undefined;
-    try {
-      const config = await resolveCommsCredentials(tenantId, 'email', configLabel);
-      auth = {
-        apiKey: config.credentials.api_key,
-        senderName: config.senderIdentity.sender_name,
-        senderEmail: config.senderIdentity.sender_email,
-      };
-      // Capture tenant context for custom_args injection (event webhook correlation)
-      tenantContext = { _tenantId: tenantId, _configLabel: config.label };
-    } catch (err: unknown) {
-      res
-        .status(500)
-        .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve email credentials' });
-      return;
-    }
-
-    const { type, to, ...p } = req.body as Record<string, unknown>;
+    const { type, to, configLabel, ...p } = req.body as Record<string, unknown>;
 
     if (!type || typeof type !== 'string') {
       res.status(400).json({ ok: false, error: 'type is required' });
       return;
     }
 
-    if (type !== 'cancel' && !to) {
+    if (type !== 'cancel' && type !== 'bulk' && type !== 'bulk-dynamic' && !to) {
       res.status(400).json({ ok: false, error: 'to is required' });
       return;
     }
 
     try {
-      let result: unknown;
-      const dest = to as string | string[];
+      // Map test page type names to unified service type names
+      const unifiedType =
+        type === 'attachment' ? 'html_attachments' : type === 'scheduled_dynamic' ? 'scheduled_dynamic' : type;
 
-      switch (type) {
-        case 'html':
-          result = await handleHtml(auth, dest, p, tenantContext);
-          break;
-        case 'dynamic':
-          result = await handleDynamic(auth, dest, p, tenantContext);
-          break;
-        case 'attachment':
-          result = await handleAttachment(auth, dest, p, tenantContext);
-          break;
-        case 'bulk':
-          result = await handleBulk(auth, p, tenantContext);
-          break;
-        case 'bulk-dynamic':
-          result = await handleBulkDynamic(auth, p, tenantContext);
-          break;
-        case 'scheduled':
-          result = await handleScheduled(auth, dest, p, res, tenantContext);
-          if (result === null) return;
-          break;
-        case 'cancel':
-          result = await handleCancel(auth, p, res);
-          if (result === null) return;
-          break;
-        default:
-          res.status(400).json({ ok: false, error: `unknown type: ${type}` });
+      if (UNIFIED_TYPES.has(type)) {
+        // Build opts with tenant context for custom_args injection
+        const opts = buildOpts(
+          p,
+          configLabel ? { _tenantId: tenantId, _configLabel: configLabel as string } : undefined,
+        );
+
+        const result = await send({
+          tenantId,
+          configLabel: configLabel as string | undefined,
+          channel: 'email',
+          to: to as string,
+          type: unifiedType,
+          payload: { ...p, opts },
+        });
+        if (!result.success) {
+          res.status(500).json({ ok: false, error: result.error });
           return;
-      }
+        }
+        res.json({ ok: true, result });
+      } else {
+        // Non-unified types — resolve credentials manually
+        const config = await resolveCommsCredentials(tenantId, 'email', configLabel as string | undefined);
+        const auth: SendGridAuth = {
+          apiKey: config.credentials.api_key,
+          senderName: config.senderIdentity.sender_name,
+          senderEmail: config.senderIdentity.sender_email,
+        };
+        const tenantContext = { _tenantId: tenantId, _configLabel: config.label };
 
-      res.json({ ok: true, result });
+        let result: unknown;
+        switch (type) {
+          case 'bulk':
+            result = await handleBulk(auth, p, tenantContext);
+            break;
+          case 'bulk-dynamic':
+            result = await handleBulkDynamic(auth, p, tenantContext);
+            break;
+          case 'cancel':
+            result = await handleCancel(auth, p, res);
+            if (result === null) return;
+            break;
+          default:
+            res.status(400).json({ ok: false, error: `Unknown type: ${type}` });
+            return;
+        }
+
+        res.json({ ok: true, result });
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An unexpected error occurred';
       res.status(500).json({ ok: false, error: message });
+    }
+  })
+
+  // ── POST /api/sample-api/sendgrid/broadcast ─────────────────────────────────
+  // Send the same email to multiple recipients.
+  // Body: { recipients: string[], type, configLabel?, subject, html/templateId/dynamicData }
+  // Example: { recipients: ["a@b.com", "c@d.com"], type: "html", subject: "Hello", html: "<p>Hi!</p>" }
+  .post('/broadcast', async (req: Request, res: Response) => {
+    const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const { recipients, type, configLabel, ...payload } = req.body as Record<string, unknown>;
+
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      res.status(400).json({ ok: false, error: 'recipients (array of email addresses) is required' });
+      return;
+    }
+
+    if (!type || typeof type !== 'string') {
+      res.status(400).json({ ok: false, error: 'type is required' });
+      return;
+    }
+
+    try {
+      const result = await broadcast({
+        tenantId,
+        configLabel: configLabel as string | undefined,
+        channel: 'email',
+        recipients: recipients as string[],
+        type: type === 'attachment' ? 'html_attachments' : type,
+        payload,
+        options: { mode: 'sequential', delayMs: 100 },
+      });
+      res.json({ ok: result.success, result });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }
   });

--- a/apps/sample-api/src/sendgrid/routes.ts
+++ b/apps/sample-api/src/sendgrid/routes.ts
@@ -21,7 +21,10 @@ import express from 'express';
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /** Extract common send options from the request payload */
-function buildOpts(p: Record<string, unknown>): SgSendEmailOpts {
+function buildOpts(
+  p: Record<string, unknown>,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+): SgSendEmailOpts {
   const opts: SgSendEmailOpts = {};
   if (p.cc) opts.cc = p.cc as SgSendEmailOpts['cc'];
   if (p.bcc) opts.bcc = p.bcc as SgSendEmailOpts['bcc'];
@@ -29,23 +32,43 @@ function buildOpts(p: Record<string, unknown>): SgSendEmailOpts {
   if (p.attachments) opts.attachments = p.attachments as SgAttachment[];
   if (p.sendAt) opts.sendAt = Number(p.sendAt);
   if (p.categories) opts.categories = p.categories as string[];
+  // Inject tenant context for event webhook correlation
+  if (tenantContext) {
+    opts._tenantId = tenantContext._tenantId;
+    opts._configLabel = tenantContext._configLabel;
+  }
   return opts;
 }
 
 // ─── Type handlers ────────────────────────────────────────────────────────────
 
-async function handleHtml(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>) {
-  const opts = buildOpts(p);
+async function handleHtml(
+  auth: SendGridAuth,
+  dest: string | string[],
+  p: Record<string, unknown>,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+) {
+  const opts = buildOpts(p, tenantContext);
   return sendEmail(auth, dest, String(p.subject ?? 'Test Email'), String(p.html ?? ''), opts);
 }
 
-async function handleDynamic(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>) {
-  const opts = buildOpts(p);
+async function handleDynamic(
+  auth: SendGridAuth,
+  dest: string | string[],
+  p: Record<string, unknown>,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+) {
+  const opts = buildOpts(p, tenantContext);
   return sendDynamicEmail(auth, dest, String(p.templateId ?? ''), (p.data as Record<string, unknown>) ?? {}, opts);
 }
 
-async function handleAttachment(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>) {
-  const opts = buildOpts(p);
+async function handleAttachment(
+  auth: SendGridAuth,
+  dest: string | string[],
+  p: Record<string, unknown>,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+) {
+  const opts = buildOpts(p, tenantContext);
   // attachments are passed as both the required param and in opts (sendEmailWithAttachments merges them)
   delete opts.attachments;
   return sendEmailWithAttachments(
@@ -58,8 +81,12 @@ async function handleAttachment(auth: SendGridAuth, dest: string | string[], p: 
   );
 }
 
-async function handleBulk(auth: SendGridAuth, p: Record<string, unknown>) {
-  const opts = buildOpts(p);
+async function handleBulk(
+  auth: SendGridAuth,
+  p: Record<string, unknown>,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+) {
+  const opts = buildOpts(p, tenantContext);
   return sendBulkEmail(
     auth,
     (p.personalizations as SgPersonalization[]) ?? [],
@@ -69,8 +96,12 @@ async function handleBulk(auth: SendGridAuth, p: Record<string, unknown>) {
   );
 }
 
-async function handleBulkDynamic(auth: SendGridAuth, p: Record<string, unknown>) {
-  const opts = buildOpts(p);
+async function handleBulkDynamic(
+  auth: SendGridAuth,
+  p: Record<string, unknown>,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+) {
+  const opts = buildOpts(p, tenantContext);
   return sendBulkDynamicEmail(
     auth,
     String(p.templateId ?? ''),
@@ -79,13 +110,19 @@ async function handleBulkDynamic(auth: SendGridAuth, p: Record<string, unknown>)
   );
 }
 
-async function handleScheduled(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>, res: Response) {
+async function handleScheduled(
+  auth: SendGridAuth,
+  dest: string | string[],
+  p: Record<string, unknown>,
+  res: Response,
+  tenantContext?: { _tenantId: number; _configLabel: string },
+) {
   const sendAt = Number(p.sendAt);
   if (!sendAt || Number.isNaN(sendAt)) {
     res.status(400).json({ ok: false, error: 'sendAt (unix timestamp) is required for scheduled type' });
     return null;
   }
-  const opts = buildOpts(p);
+  const opts = buildOpts(p, tenantContext);
   return sendScheduledEmail(auth, dest, String(p.subject ?? 'Scheduled Email'), String(p.html ?? ''), sendAt, opts);
 }
 
@@ -117,6 +154,7 @@ export default express
     const { configLabel } = req.body as { configLabel?: string };
 
     let auth: SendGridAuth;
+    let tenantContext: { _tenantId: number; _configLabel: string } | undefined;
     try {
       const config = await resolveCommsCredentials(tenantId, 'email', configLabel);
       auth = {
@@ -124,6 +162,8 @@ export default express
         senderName: config.senderIdentity.sender_name,
         senderEmail: config.senderIdentity.sender_email,
       };
+      // Capture tenant context for custom_args injection (event webhook correlation)
+      tenantContext = { _tenantId: tenantId, _configLabel: config.label };
     } catch (err: unknown) {
       res
         .status(500)
@@ -149,22 +189,22 @@ export default express
 
       switch (type) {
         case 'html':
-          result = await handleHtml(auth, dest, p);
+          result = await handleHtml(auth, dest, p, tenantContext);
           break;
         case 'dynamic':
-          result = await handleDynamic(auth, dest, p);
+          result = await handleDynamic(auth, dest, p, tenantContext);
           break;
         case 'attachment':
-          result = await handleAttachment(auth, dest, p);
+          result = await handleAttachment(auth, dest, p, tenantContext);
           break;
         case 'bulk':
-          result = await handleBulk(auth, p);
+          result = await handleBulk(auth, p, tenantContext);
           break;
         case 'bulk-dynamic':
-          result = await handleBulkDynamic(auth, p);
+          result = await handleBulkDynamic(auth, p, tenantContext);
           break;
         case 'scheduled':
-          result = await handleScheduled(auth, dest, p, res);
+          result = await handleScheduled(auth, dest, p, res, tenantContext);
           if (result === null) return;
           break;
         case 'cancel':

--- a/apps/sample-api/src/sendgrid/routes.ts
+++ b/apps/sample-api/src/sendgrid/routes.ts
@@ -7,17 +7,16 @@ import {
   sendEmailWithAttachments,
   sendScheduledEmail,
 } from '@common/node/comms/sendgrid/outbound';
-import type { SgAttachment, SgPersonalization, SgSendEmailOpts } from '@common/node/comms/sendgrid/types';
+import type { SendGridAuth, SgAttachment, SgPersonalization, SgSendEmailOpts } from '@common/node/comms/sendgrid/types';
+import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import type { Request, Response } from 'express';
 import express from 'express';
 
 // SendGrid email test dispatcher
 // Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
 //
-// Required env vars (set in .env.local):
-//   SENDGRID_KEY          — API key from SendGrid Dashboard → Settings → API Keys
-//   SENDGRID_SENDER_NAME  — display name in From field
-//   SENDGRID_SENDER_EMAIL — verified sender email address
+// Credentials are resolved per-tenant from the database via resolveCommsCredentials().
+// Each tenant must configure their own SendGrid API key and sender identity.
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -35,21 +34,22 @@ function buildOpts(p: Record<string, unknown>): SgSendEmailOpts {
 
 // ─── Type handlers ────────────────────────────────────────────────────────────
 
-async function handleHtml(dest: string | string[], p: Record<string, unknown>) {
+async function handleHtml(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>) {
   const opts = buildOpts(p);
-  return sendEmail(dest, String(p.subject ?? 'Test Email'), String(p.html ?? ''), opts);
+  return sendEmail(auth, dest, String(p.subject ?? 'Test Email'), String(p.html ?? ''), opts);
 }
 
-async function handleDynamic(dest: string | string[], p: Record<string, unknown>) {
+async function handleDynamic(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>) {
   const opts = buildOpts(p);
-  return sendDynamicEmail(dest, String(p.templateId ?? ''), (p.data as Record<string, unknown>) ?? {}, opts);
+  return sendDynamicEmail(auth, dest, String(p.templateId ?? ''), (p.data as Record<string, unknown>) ?? {}, opts);
 }
 
-async function handleAttachment(dest: string | string[], p: Record<string, unknown>) {
+async function handleAttachment(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>) {
   const opts = buildOpts(p);
   // attachments are passed as both the required param and in opts (sendEmailWithAttachments merges them)
   delete opts.attachments;
   return sendEmailWithAttachments(
+    auth,
     dest,
     String(p.subject ?? 'Test Email'),
     String(p.html ?? ''),
@@ -58,9 +58,10 @@ async function handleAttachment(dest: string | string[], p: Record<string, unkno
   );
 }
 
-async function handleBulk(p: Record<string, unknown>) {
+async function handleBulk(auth: SendGridAuth, p: Record<string, unknown>) {
   const opts = buildOpts(p);
   return sendBulkEmail(
+    auth,
     (p.personalizations as SgPersonalization[]) ?? [],
     String(p.subject ?? 'Bulk Email'),
     String(p.html ?? ''),
@@ -68,27 +69,32 @@ async function handleBulk(p: Record<string, unknown>) {
   );
 }
 
-async function handleBulkDynamic(p: Record<string, unknown>) {
+async function handleBulkDynamic(auth: SendGridAuth, p: Record<string, unknown>) {
   const opts = buildOpts(p);
-  return sendBulkDynamicEmail(String(p.templateId ?? ''), (p.personalizations as SgPersonalization[]) ?? [], opts);
+  return sendBulkDynamicEmail(
+    auth,
+    String(p.templateId ?? ''),
+    (p.personalizations as SgPersonalization[]) ?? [],
+    opts,
+  );
 }
 
-async function handleScheduled(dest: string | string[], p: Record<string, unknown>, res: Response) {
+async function handleScheduled(auth: SendGridAuth, dest: string | string[], p: Record<string, unknown>, res: Response) {
   const sendAt = Number(p.sendAt);
   if (!sendAt || Number.isNaN(sendAt)) {
     res.status(400).json({ ok: false, error: 'sendAt (unix timestamp) is required for scheduled type' });
     return null;
   }
   const opts = buildOpts(p);
-  return sendScheduledEmail(dest, String(p.subject ?? 'Scheduled Email'), String(p.html ?? ''), sendAt, opts);
+  return sendScheduledEmail(auth, dest, String(p.subject ?? 'Scheduled Email'), String(p.html ?? ''), sendAt, opts);
 }
 
-async function handleCancel(p: Record<string, unknown>, res: Response) {
+async function handleCancel(auth: SendGridAuth, p: Record<string, unknown>, res: Response) {
   if (!p.batchId) {
     res.status(400).json({ ok: false, error: 'batchId is required for cancel type' });
     return null;
   }
-  return cancelScheduledEmail(String(p.batchId ?? ''));
+  return cancelScheduledEmail(auth, String(p.batchId ?? ''));
 }
 
 // ─── Route ────────────────────────────────────────────────────────────────────
@@ -97,10 +103,32 @@ export default express
   .Router()
 
   // ── POST /api/sample-api/sendgrid/test ────────────────────────────────────────
-  // Multi-type test dispatcher — no auth.
+  // Multi-type test dispatcher.
   // Body: { type, to, ...type-specific fields }
+  // Requires authenticated user with tenant_id for credential resolution.
   // See EmailTest.vue for sample payloads per type.
   .post('/test', async (req: Request, res: Response) => {
+    const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    let auth: SendGridAuth;
+    try {
+      const config = await resolveCommsCredentials(tenantId, 'email');
+      auth = {
+        apiKey: config.credentials.api_key,
+        senderName: config.senderIdentity.sender_name,
+        senderEmail: config.senderIdentity.sender_email,
+      };
+    } catch (err: unknown) {
+      res
+        .status(500)
+        .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve email credentials' });
+      return;
+    }
+
     const { type, to, ...p } = req.body as Record<string, unknown>;
 
     if (!type || typeof type !== 'string') {
@@ -119,26 +147,26 @@ export default express
 
       switch (type) {
         case 'html':
-          result = await handleHtml(dest, p);
+          result = await handleHtml(auth, dest, p);
           break;
         case 'dynamic':
-          result = await handleDynamic(dest, p);
+          result = await handleDynamic(auth, dest, p);
           break;
         case 'attachment':
-          result = await handleAttachment(dest, p);
+          result = await handleAttachment(auth, dest, p);
           break;
         case 'bulk':
-          result = await handleBulk(p);
+          result = await handleBulk(auth, p);
           break;
         case 'bulk-dynamic':
-          result = await handleBulkDynamic(p);
+          result = await handleBulkDynamic(auth, p);
           break;
         case 'scheduled':
-          result = await handleScheduled(dest, p, res);
+          result = await handleScheduled(auth, dest, p, res);
           if (result === null) return;
           break;
         case 'cancel':
-          result = await handleCancel(p, res);
+          result = await handleCancel(auth, p, res);
           if (result === null) return;
           break;
         default:

--- a/apps/sample-api/src/sendgrid/routes.ts
+++ b/apps/sample-api/src/sendgrid/routes.ts
@@ -114,9 +114,11 @@ export default express
       return;
     }
 
+    const { configLabel } = req.body as { configLabel?: string };
+
     let auth: SendGridAuth;
     try {
-      const config = await resolveCommsCredentials(tenantId, 'email');
+      const config = await resolveCommsCredentials(tenantId, 'email', configLabel);
       auth = {
         apiKey: config.credentials.api_key,
         senderName: config.senderIdentity.sender_name,

--- a/apps/sample-api/src/sendgrid/routes.ts
+++ b/apps/sample-api/src/sendgrid/routes.ts
@@ -2,6 +2,7 @@ import { cancelScheduledEmail, sendBulkDynamicEmail, sendBulkEmail } from '@comm
 import type { SendGridAuth, SgAttachment, SgPersonalization, SgSendEmailOpts } from '@common/node/comms/sendgrid/types';
 import { broadcast } from '@common/node/comms/service/broadcast';
 import { send } from '@common/node/comms/service/send';
+import type { SendRequest } from '@common/node/comms/service/types';
 import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import type { Request, Response } from 'express';
 import express from 'express';
@@ -123,7 +124,7 @@ export default express
           to: to as string,
           type: unifiedType,
           payload: { ...p, opts },
-        });
+        } as unknown as SendRequest);
         if (!result.success) {
           res.status(500).json({ ok: false, error: result.error });
           return;
@@ -196,7 +197,7 @@ export default express
         type: type === 'attachment' ? 'html_attachments' : type,
         payload,
         options: { mode: 'sequential', delayMs: 100 },
-      });
+      } as unknown as Parameters<typeof broadcast>[0]);
       res.json({ ok: result.success, result });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });

--- a/apps/sample-api/src/sendgrid/template-routes.ts
+++ b/apps/sample-api/src/sendgrid/template-routes.ts
@@ -11,15 +11,15 @@ import {
   updateTemplateVersion,
 } from '@common/node/comms/sendgrid/template';
 import type { SgTemplateVersionData } from '@common/node/comms/sendgrid/types';
+import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import type { Request, Response } from 'express';
 import express from 'express';
 
 // SendGrid Dynamic Templates API routes
 // Docs: https://docs.sendgrid.com/api-reference/transactional-templates/
 //
-// Required env vars:
-//   SENDGRID_KEY — API key from SendGrid Dashboard → Settings → API Keys
-//                  Permissions: Template Engine (Full Access)
+// Credentials are resolved per-tenant from the database via resolveCommsCredentials().
+// Pass ?configLabel=xxx query param to select which email config to use.
 
 function handleError(res: Response, err: unknown, context: string) {
   const msg = err instanceof Error ? err.message : 'An unexpected error occurred';
@@ -27,16 +27,37 @@ function handleError(res: Response, err: unknown, context: string) {
   res.status(500).json({ ok: false, error: msg });
 }
 
+async function getApiKey(req: Request, res: Response): Promise<string | null> {
+  const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+  if (!tenantId) {
+    res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+    return null;
+  }
+  const configLabel = (req.query.configLabel as string) || (req.body?.configLabel as string) || undefined;
+  try {
+    const config = await resolveCommsCredentials(tenantId, 'email', configLabel);
+    return config.credentials.api_key;
+  } catch (err: unknown) {
+    res
+      .status(500)
+      .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve email credentials' });
+    return null;
+  }
+}
+
 export default express
   .Router()
 
   // ── GET /api/sample-api/sendgrid/templates ──────────────────────────────────
-  // List all dynamic templates. Query: ?pageSize=N&pageToken=xxx
+  // List all dynamic templates. Query: ?pageSize=N&pageToken=xxx&configLabel=xxx
   .get('/', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     const pageSize = req.query.pageSize ? Number(req.query.pageSize) : undefined;
     const pageToken = req.query.pageToken ? String(req.query.pageToken) : undefined;
     try {
-      const data = await listTemplates({ pageSize, pageToken });
+      const data = await listTemplates(apiKey, { pageSize, pageToken });
       res.json({ ok: true, templates: data.templates ?? [] });
     } catch (err: unknown) {
       handleError(res, err, 'list');
@@ -44,15 +65,18 @@ export default express
   })
 
   // ── POST /api/sample-api/sendgrid/templates ─────────────────────────────────
-  // Create a new (empty) dynamic template. Body: { name }
+  // Create a new (empty) dynamic template. Body: { name, configLabel? }
   .post('/', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     const { name } = req.body as { name?: string };
     if (!name) {
       res.status(400).json({ ok: false, error: 'name is required' });
       return;
     }
     try {
-      const result = await createTemplate(name);
+      const result = await createTemplate(apiKey, name);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'create');
@@ -62,8 +86,11 @@ export default express
   // ── GET /api/sample-api/sendgrid/templates/:id ──────────────────────────────
   // Get a single template with all its versions.
   .get('/:id', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     try {
-      const result = await getTemplate(req.params.id);
+      const result = await getTemplate(apiKey, req.params.id);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'get');
@@ -71,15 +98,18 @@ export default express
   })
 
   // ── PATCH /api/sample-api/sendgrid/templates/:id ────────────────────────────
-  // Rename a template. Body: { name }
+  // Rename a template. Body: { name, configLabel? }
   .patch('/:id', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     const { name } = req.body as { name?: string };
     if (!name) {
       res.status(400).json({ ok: false, error: 'name is required' });
       return;
     }
     try {
-      const result = await updateTemplate(req.params.id, name);
+      const result = await updateTemplate(apiKey, req.params.id, name);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'update');
@@ -87,11 +117,14 @@ export default express
   })
 
   // ── POST /api/sample-api/sendgrid/templates/:id/duplicate ──────────────────
-  // Duplicate a template. Body: { name? }
+  // Duplicate a template. Body: { name?, configLabel? }
   .post('/:id/duplicate', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     const { name } = req.body as { name?: string };
     try {
-      const result = await duplicateTemplate(req.params.id, name);
+      const result = await duplicateTemplate(apiKey, req.params.id, name);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'duplicate');
@@ -101,8 +134,11 @@ export default express
   // ── DELETE /api/sample-api/sendgrid/templates/:id ───────────────────────────
   // Delete a template and all its versions.
   .delete('/:id', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     try {
-      await deleteTemplate(req.params.id);
+      await deleteTemplate(apiKey, req.params.id);
       res.json({ ok: true });
     } catch (err: unknown) {
       handleError(res, err, 'delete');
@@ -110,15 +146,18 @@ export default express
   })
 
   // ── POST /api/sample-api/sendgrid/templates/:id/versions ───────────────────
-  // Create a new version. Body: SgTemplateVersionData
+  // Create a new version. Body: SgTemplateVersionData & { configLabel? }
   .post('/:id/versions', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     const data = req.body as SgTemplateVersionData;
     if (!data.name) {
       res.status(400).json({ ok: false, error: 'name is required' });
       return;
     }
     try {
-      const result = await createTemplateVersion(req.params.id, data);
+      const result = await createTemplateVersion(apiKey, req.params.id, data);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'createVersion');
@@ -128,9 +167,12 @@ export default express
   // ── PATCH /api/sample-api/sendgrid/templates/:id/versions/:vid ─────────────
   // Update a version's content, subject or name.
   .patch('/:id/versions/:vid', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     const data = req.body as Partial<SgTemplateVersionData>;
     try {
-      const result = await updateTemplateVersion(req.params.id, req.params.vid, data);
+      const result = await updateTemplateVersion(apiKey, req.params.id, req.params.vid, data);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'updateVersion');
@@ -140,8 +182,11 @@ export default express
   // ── POST /api/sample-api/sendgrid/templates/:id/versions/:vid/activate ─────
   // Activate a version (make it the live version for this template).
   .post('/:id/versions/:vid/activate', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     try {
-      const result = await activateTemplateVersion(req.params.id, req.params.vid);
+      const result = await activateTemplateVersion(apiKey, req.params.id, req.params.vid);
       res.json({ ok: true, ...result });
     } catch (err: unknown) {
       handleError(res, err, 'activateVersion');
@@ -151,8 +196,11 @@ export default express
   // ── DELETE /api/sample-api/sendgrid/templates/:id/versions/:vid ────────────
   // Permanently delete a template version.
   .delete('/:id/versions/:vid', async (req: Request, res: Response) => {
+    const apiKey = await getApiKey(req, res);
+    if (!apiKey) return;
+
     try {
-      await deleteTemplateVersion(req.params.id, req.params.vid);
+      await deleteTemplateVersion(apiKey, req.params.id, req.params.vid);
       res.json({ ok: true });
     } catch (err: unknown) {
       handleError(res, err, 'deleteVersion');

--- a/apps/sample-api/src/sendgrid/webhook-routes.ts
+++ b/apps/sample-api/src/sendgrid/webhook-routes.ts
@@ -1,5 +1,6 @@
 import { parseEventWebhook, verifyEventWebhookSignature } from '@common/node/comms/sendgrid/events';
 import { parseInboundEmail } from '@common/node/comms/sendgrid/inbound';
+import { resolveCommsConfigByIdentity, resolveCommsConfigByLabel } from '@common/node/comms/tenant/resolver';
 import { memoryUpload } from '@common/node/express/upload';
 import type { Request, Response } from 'express';
 import express from 'express';
@@ -9,8 +10,10 @@ import express from 'express';
 //   Inbound Parse: https://docs.sendgrid.com/for-developers/parsing-email/setting-up-the-inbound-parse-webhook
 //   Event Webhook: https://docs.sendgrid.com/for-developers/tracking-events/event
 //
-// Required env vars:
-//   SENDGRID_EVENT_WEBHOOK_KEY — ECDSA public key for verifying event webhook signatures (optional, skips verification if not set)
+// Multi-config architecture:
+//   - Inbound Parse: routes by matching envelope.to address to config's sender_email (reverse lookup)
+//   - Event Webhook: path-based routing (/events/:label) for signature verification + custom_args fallback
+//   - Falls back to env vars (SENDGRID_EVENT_WEBHOOK_KEY) for backward compat
 
 const upload = memoryUpload({ limits: { fileSize: 30 * 1024 * 1024, files: 20 } });
 
@@ -19,11 +22,11 @@ export default express
 
   // ── POST /api/sample-api/sendgrid/inbound ─────────────────────────────────────
   // SendGrid Inbound Parse webhook — receives emails sent to your parse domain.
-  // Payload: multipart/form-data with text fields + file attachments.
+  // Multi-config: resolves config by matching the recipient (to) address to sender_email.
   //
   // Setup: SendGrid Dashboard > Settings > Inbound Parse > Add Host & URL
   //   Hostname: parse.yourdomain.com (needs MX record pointing to mx.sendgrid.net)
-  //   URL: https://your-ngrok-url/api/sample-api/sendgrid/inbound
+  //   URL: https://your-domain/api/sample-api/sendgrid/inbound
   //
   // For dev/testing: POST a mock multipart/form-data payload directly (no MX record needed).
   .post('/inbound', upload.any(), async (req: Request, res: Response) => {
@@ -44,109 +47,270 @@ export default express
       ).files;
       const email = parseInboundEmail(req.body, files);
 
-      logger.info('[Email Inbound] Received', {
-        from: email.from,
-        to: email.to,
-        subject: email.subject,
-        attachments: email.attachmentCount,
-        spf: email.spf,
-      });
+      // Resolve config by recipient email address (envelope.to[0] → sender_email in config)
+      const recipientEmail = email.envelope.to[0] ?? '';
+      const config = await resolveCommsConfigByIdentity('email', 'sender_email', recipientEmail);
 
-      // ── Auto-reply example ────────────────────────────────────────────────
-      // Uncomment the block below to send an automatic reply to every inbound email.
-      // In production, add your own logic (e.g. ticket creation, AI agent, etc.)
-      //
-      // const senderEmail = email.envelope.from;
-      // if (senderEmail) {
-      //   await sendEmail(
-      //     senderEmail,
-      //     `Re: ${email.subject}`,
-      //     `<p>Thank you for your email. We received your message:</p><blockquote>${email.text || email.html}</blockquote><p>We will get back to you shortly.</p>`,
-      //   );
-      //   logger.info('[Email Inbound] Auto-reply sent', { to: senderEmail });
-      // }
+      if (config) {
+        logger.info('[Email Inbound] Received (multi-config)', {
+          tenant: config.tenantId,
+          configLabel: config.label,
+          from: email.from,
+          to: email.to,
+          subject: email.subject,
+          attachments: email.attachmentCount,
+          spf: email.spf,
+        });
+
+        // ── Process in tenant context ─────────────────────────────────────────
+        // Replace with your own logic: ticket creation, AI agent, auto-reply, etc.
+        // config.tenantId — the tenant this email belongs to
+        // config.label — the specific email config (e.g., "support-email")
+        // config.credentials.api_key — can be used to send a reply
+      } else {
+        // No config found — log as unrouted
+        logger.info('[Email Inbound] Received (no config match)', {
+          from: email.from,
+          to: email.to,
+          recipientEmail,
+          subject: email.subject,
+          attachments: email.attachmentCount,
+          spf: email.spf,
+        });
+      }
     } catch (err: unknown) {
       logger.error('[Email Inbound] Parse failed', { error: err instanceof Error ? err.message : String(err) });
     }
   })
 
-  // ── POST /api/sample-api/sendgrid/events ──────────────────────────────────────
-  // SendGrid Event Webhook — receives delivery/engagement events (delivered, bounce, open, click, etc.)
-  // Payload: JSON array of event objects.
+  // ── POST /api/sample-api/sendgrid/events/:label ───────────────────────────────
+  // SendGrid Event Webhook — per-config endpoint with ECDSA signature verification.
+  // Each config gets its own event webhook URL registered in SendGrid Dashboard.
   //
   // Setup: SendGrid Dashboard > Settings > Mail Settings > Event Webhook
-  //   HTTP Post URL: https://your-ngrok-url/api/sample-api/sendgrid/events
-  //   Events: check all events you want to receive
-  //   Signed Event Webhook: ON (recommended — provides ECDSA signature verification)
-  .post('/events', express.json({ limit: '5mb' }), async (req: Request, res: Response) => {
-    // ── Signature verification (optional — skipped if key not configured) ────
-    const publicKey = process.env.SENDGRID_EVENT_WEBHOOK_KEY;
-    if (publicKey) {
-      const signature = String(req.headers['x-twilio-email-event-webhook-signature'] ?? '');
-      const timestamp = String(req.headers['x-twilio-email-event-webhook-timestamp'] ?? '');
-      const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+  //   HTTP Post URL: https://your-domain/api/sample-api/sendgrid/events/<config-label>
+  //   Signed Event Webhook: ON (provides ECDSA signature verification)
+  .post(
+    '/events/:label',
+    express.json({
+      limit: '5mb',
+      verify: (req, _res, buf) => {
+        (req as any).rawBody = buf;
+      },
+    }),
+    async (req: Request, res: Response) => {
+      const { label } = req.params;
 
-      if (!rawBody) {
-        logger.warn('[Email Events] No raw body available for signature verification');
-        res.sendStatus(403);
+      // Resolve config by label
+      const config = await resolveCommsConfigByLabel('email', label);
+      if (!config) {
+        res.sendStatus(404);
         return;
       }
 
-      const isValid = verifyEventWebhookSignature(publicKey, rawBody, signature, timestamp);
-      if (!isValid) {
-        logger.warn('[Email Events] Invalid signature — rejecting');
-        res.sendStatus(403);
-        return;
-      }
-    }
+      // Signature verification using config's event_webhook_public_key
+      const publicKey = config.credentials.event_webhook_public_key;
+      if (publicKey) {
+        const signature = String(req.headers['x-twilio-email-event-webhook-signature'] ?? '');
+        const timestamp = String(req.headers['x-twilio-email-event-webhook-timestamp'] ?? '');
+        const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
 
-    // Always respond 200 — SendGrid retries on non-2xx
-    res.sendStatus(200);
+        if (!rawBody) {
+          logger.warn('[Email Events] No raw body available for signature verification', { label });
+          res.sendStatus(403);
+          return;
+        }
 
-    try {
-      const events = parseEventWebhook(req.body);
-
-      for (const evt of events) {
-        switch (evt.event) {
-          case 'delivered':
-            logger.info('[Email Events] Delivered', { email: evt.email, sgMessageId: evt.sgMessageId });
-            break;
-          case 'bounce':
-            logger.warn('[Email Events] Bounce', { email: evt.email, reason: evt.reason, type: evt.bounceType });
-            break;
-          case 'open':
-            logger.info('[Email Events] Opened', { email: evt.email, machineOpen: evt.sgMachineOpen });
-            break;
-          case 'click':
-            logger.info('[Email Events] Clicked', { email: evt.email, url: evt.url });
-            break;
-          case 'spamreport':
-            logger.warn('[Email Events] Spam report', { email: evt.email });
-            break;
-          case 'unsubscribe':
-          case 'group_unsubscribe':
-            logger.warn('[Email Events] Unsubscribe', { email: evt.email, event: evt.event });
-            break;
-          case 'dropped':
-            logger.warn('[Email Events] Dropped', { email: evt.email, reason: evt.dropReason });
-            break;
-          case 'deferred':
-            logger.info('[Email Events] Deferred', { email: evt.email, attempt: evt.attempt });
-            break;
-          default:
-            logger.debug('[Email Events] Event', { event: evt.event, email: evt.email });
+        const isValid = verifyEventWebhookSignature(publicKey, rawBody, signature, timestamp);
+        if (!isValid) {
+          logger.warn('[Email Events] Invalid signature — rejecting', { label });
+          res.sendStatus(403);
+          return;
         }
       }
 
-      // ── Custom event handling ───────────────────────────────────────────────
-      // Add your own logic here, e.g.:
-      // - Store events in a database for analytics
-      // - Trigger alerts on bounces/spam reports
-      // - Update user engagement scores
-      // - Remove bounced addresses from mailing lists
-    } catch (err: unknown) {
-      logger.error('[Email Events] Parse failed', {
-        error: err instanceof Error ? err.message : 'An unexpected error occurred',
-      });
-    }
-  });
+      // Always respond 200 — SendGrid retries on non-2xx
+      res.sendStatus(200);
+
+      try {
+        const events = parseEventWebhook(req.body);
+
+        for (const evt of events) {
+          switch (evt.event) {
+            case 'delivered':
+              logger.info('[Email Events] Delivered', {
+                tenant: config.tenantId,
+                label,
+                email: evt.email,
+                sgMessageId: evt.sgMessageId,
+              });
+              break;
+            case 'bounce':
+              logger.warn('[Email Events] Bounce', {
+                tenant: config.tenantId,
+                label,
+                email: evt.email,
+                reason: evt.reason,
+                type: evt.bounceType,
+              });
+              break;
+            case 'open':
+              logger.info('[Email Events] Opened', {
+                tenant: config.tenantId,
+                label,
+                email: evt.email,
+                machineOpen: evt.sgMachineOpen,
+              });
+              break;
+            case 'click':
+              logger.info('[Email Events] Clicked', { tenant: config.tenantId, label, email: evt.email, url: evt.url });
+              break;
+            case 'spamreport':
+              logger.warn('[Email Events] Spam report', { tenant: config.tenantId, label, email: evt.email });
+              break;
+            case 'unsubscribe':
+            case 'group_unsubscribe':
+              logger.warn('[Email Events] Unsubscribe', {
+                tenant: config.tenantId,
+                label,
+                email: evt.email,
+                event: evt.event,
+              });
+              break;
+            case 'dropped':
+              logger.warn('[Email Events] Dropped', {
+                tenant: config.tenantId,
+                label,
+                email: evt.email,
+                reason: evt.dropReason,
+              });
+              break;
+            case 'deferred':
+              logger.info('[Email Events] Deferred', {
+                tenant: config.tenantId,
+                label,
+                email: evt.email,
+                attempt: evt.attempt,
+              });
+              break;
+            default:
+              logger.debug('[Email Events] Event', {
+                tenant: config.tenantId,
+                label,
+                event: evt.event,
+                email: evt.email,
+              });
+          }
+        }
+      } catch (err: unknown) {
+        logger.error('[Email Events] Parse failed', {
+          label,
+          error: err instanceof Error ? err.message : 'An unexpected error occurred',
+        });
+      }
+    },
+  )
+
+  // ── POST /api/sample-api/sendgrid/events ──────────────────────────────────────
+  // Legacy event webhook endpoint (backward compatibility).
+  // Uses single SENDGRID_EVENT_WEBHOOK_KEY env var for verification.
+  // Also supports routing via custom_args (_novex_config_label, _novex_tenant_id).
+  .post(
+    '/events',
+    express.json({
+      limit: '5mb',
+      verify: (req, _res, buf) => {
+        (req as any).rawBody = buf;
+      },
+    }),
+    async (req: Request, res: Response) => {
+      // Signature verification (optional — skipped if key not configured)
+      const publicKey = process.env.SENDGRID_EVENT_WEBHOOK_KEY;
+      if (publicKey) {
+        const signature = String(req.headers['x-twilio-email-event-webhook-signature'] ?? '');
+        const timestamp = String(req.headers['x-twilio-email-event-webhook-timestamp'] ?? '');
+        const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+
+        if (!rawBody) {
+          logger.warn('[Email Events] No raw body available for signature verification');
+          res.sendStatus(403);
+          return;
+        }
+
+        const isValid = verifyEventWebhookSignature(publicKey, rawBody, signature, timestamp);
+        if (!isValid) {
+          logger.warn('[Email Events] Invalid signature — rejecting');
+          res.sendStatus(403);
+          return;
+        }
+      }
+
+      // Always respond 200 — SendGrid retries on non-2xx
+      res.sendStatus(200);
+
+      try {
+        const events = parseEventWebhook(req.body);
+
+        for (const evt of events) {
+          // Try to resolve tenant context from custom_args (injected during send)
+          const tenantId = evt.customArgs._novex_tenant_id;
+          const configLabel = evt.customArgs._novex_config_label;
+
+          switch (evt.event) {
+            case 'delivered':
+              logger.info('[Email Events] Delivered', {
+                tenantId,
+                configLabel,
+                email: evt.email,
+                sgMessageId: evt.sgMessageId,
+              });
+              break;
+            case 'bounce':
+              logger.warn('[Email Events] Bounce', {
+                tenantId,
+                configLabel,
+                email: evt.email,
+                reason: evt.reason,
+                type: evt.bounceType,
+              });
+              break;
+            case 'open':
+              logger.info('[Email Events] Opened', {
+                tenantId,
+                configLabel,
+                email: evt.email,
+                machineOpen: evt.sgMachineOpen,
+              });
+              break;
+            case 'click':
+              logger.info('[Email Events] Clicked', { tenantId, configLabel, email: evt.email, url: evt.url });
+              break;
+            case 'spamreport':
+              logger.warn('[Email Events] Spam report', { tenantId, configLabel, email: evt.email });
+              break;
+            case 'unsubscribe':
+            case 'group_unsubscribe':
+              logger.warn('[Email Events] Unsubscribe', { tenantId, configLabel, email: evt.email, event: evt.event });
+              break;
+            case 'dropped':
+              logger.warn('[Email Events] Dropped', {
+                tenantId,
+                configLabel,
+                email: evt.email,
+                reason: evt.dropReason,
+              });
+              break;
+            case 'deferred':
+              logger.info('[Email Events] Deferred', { tenantId, configLabel, email: evt.email, attempt: evt.attempt });
+              break;
+            default:
+              logger.debug('[Email Events] Event', { tenantId, configLabel, event: evt.event, email: evt.email });
+          }
+        }
+      } catch (err: unknown) {
+        logger.error('[Email Events] Parse failed', {
+          error: err instanceof Error ? err.message : 'An unexpected error occurred',
+        });
+      }
+    },
+  );

--- a/apps/sample-api/src/telegram/routes.ts
+++ b/apps/sample-api/src/telegram/routes.ts
@@ -26,7 +26,7 @@ import {
   unpinMessage,
 } from '@common/node/comms/telegram2/outbound';
 import type { ContactData, MediaGroupItem, TelegramMessageOpts, VenueData } from '@common/node/comms/telegram2/types';
-import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
+import { resolveCommsConfigByLabel, resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import type { Request, Response } from 'express';
 import express from 'express';
 
@@ -172,13 +172,57 @@ async function handleTestType(
 export default express
   .Router()
 
+  // ── POST /api/sample-api/telegram/webhook/:label ──────────────────────────
+  // Multi-config webhook endpoint. Each bot config gets its own URL.
+  // Telegram sends updates here after setWebhook is called with this URL.
+  // Verifies the X-Telegram-Bot-Api-Secret-Token header against the config's webhook_secret.
+  .post('/webhook/:label', async (req: Request, res: Response) => {
+    const { label } = req.params;
+
+    // 1. Resolve config by label
+    const config = await resolveCommsConfigByLabel('telegram', label);
+    if (!config) {
+      res.sendStatus(404);
+      return;
+    }
+
+    // 2. Verify secret_token header
+    const headerSecret = req.headers['x-telegram-bot-api-secret-token'] as string | undefined;
+    if (!headerSecret || headerSecret !== config.credentials.webhook_secret) {
+      res.sendStatus(401);
+      return;
+    }
+
+    // 3. Respond 200 immediately (Telegram expects fast response)
+    res.sendStatus(200);
+
+    // 4. Parse and process with tenant context
+    const parsed = handleUpdate(req.body);
+    if (!parsed || parsed.updateType !== 'message') return;
+
+    // biome-ignore lint/suspicious/noExplicitAny: parsed data shape varies by updateType
+    const data = parsed.data as any;
+    if (!data?.content || data.content.type !== 'text') return;
+
+    const chatId = String(data.chat?.id ?? '');
+    const userText = String(data.content.text ?? '')
+      .trim()
+      .toLowerCase();
+
+    // Simple echo handler — extend or replace with AI/service layer
+    let reply: string;
+    if (userText === 'hello' || userText === 'hi') {
+      reply = 'Hi! What can I help you with?';
+    } else {
+      reply = `You said: "${data.content.text}". (This bot is a work in progress.)`;
+    }
+
+    await sendMessage(config.credentials.bot_token, chatId, reply);
+  })
+
   // ── POST /api/sample-api/telegram/webhook ──────────────────────────────────
-  // Telegram sends every update here as a POST.
-  // Respond 200 immediately — Telegram will retry if you don't.
+  // Legacy single-bot webhook endpoint (backward compatibility).
   // Uses TELEGRAM_API_KEY env var for bot replies (not tenant-scoped).
-  // To register this webhook URL with Telegram, call:
-  //   POST https://api.telegram.org/bot<TOKEN>/setWebhook
-  //   Body: { url: "https://yourdomain.com/api/sample-api/telegram/webhook" }
   .post('/webhook', async (req, res) => {
     res.sendStatus(200); // always ack first
 

--- a/apps/sample-api/src/telegram/routes.ts
+++ b/apps/sample-api/src/telegram/routes.ts
@@ -1,5 +1,6 @@
 import { broadcast } from '@common/node/comms/service/broadcast';
 import { send } from '@common/node/comms/service/send';
+import type { SendRequest } from '@common/node/comms/service/types';
 import { handleUpdate } from '@common/node/comms/telegram2/inbound';
 import {
   copyMessage,
@@ -141,7 +142,7 @@ export default express
   // Telegram sends updates here after setWebhook is called with this URL.
   // Verifies the X-Telegram-Bot-Api-Secret-Token header against the config's webhook_secret.
   .post('/webhook/:label', async (req: Request, res: Response) => {
-    const { label } = req.params;
+    const label = String(req.params.label);
 
     // 1. Resolve config by label
     const config = await resolveCommsConfigByLabel('telegram', label);
@@ -282,7 +283,7 @@ export default express
           to: chatId,
           type: unifiedType,
           payload: p,
-        });
+        } as unknown as SendRequest);
         if (!result.success) {
           res.status(500).json({ ok: false, error: result.error });
           return;
@@ -336,7 +337,7 @@ export default express
         type: type === 'message' ? 'text' : type,
         payload,
         options: { mode: 'sequential', delayMs: 100 },
-      });
+      } as unknown as Parameters<typeof broadcast>[0]);
       res.json({ ok: result.success, result });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });

--- a/apps/sample-api/src/telegram/routes.ts
+++ b/apps/sample-api/src/telegram/routes.ts
@@ -1,3 +1,5 @@
+import { broadcast } from '@common/node/comms/service/broadcast';
+import { send } from '@common/node/comms/service/send';
 import { handleUpdate } from '@common/node/comms/telegram2/inbound';
 import {
   copyMessage,
@@ -7,41 +9,45 @@ import {
   editMessageText,
   forwardMessage,
   pinMessage,
-  sendAnimation,
-  sendAudio,
   sendChatAction,
-  sendContact,
-  sendDice,
-  sendDocument,
-  sendLocation,
   sendMediaGroup,
   sendMessage,
-  sendPhoto,
-  sendPoll,
-  sendSticker,
-  sendVenue,
-  sendVideo,
-  sendVideoNote,
-  sendVoice,
   unpinMessage,
 } from '@common/node/comms/telegram2/outbound';
-import type { ContactData, MediaGroupItem, TelegramMessageOpts, VenueData } from '@common/node/comms/telegram2/types';
-import { resolveCommsConfigByLabel, resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
+import type { MediaGroupItem, TelegramMessageOpts } from '@common/node/comms/telegram2/types';
+import { resolveCommsConfigByLabel } from '@common/node/comms/tenant/resolver';
 import type { Request, Response } from 'express';
 import express from 'express';
 
 // Telegram Bot API test dispatcher
 // Docs: https://core.telegram.org/bots/api/
 //
-// Credentials are resolved per-tenant from the database via resolveCommsCredentials().
+// Credentials are resolved per-tenant from the database via the unified comms service.
 // Each tenant must configure their own Telegram Bot Token in the Comms Config page.
 //
-// Required env var (for the inbound webhook handler only):
+// Required env var (for the legacy inbound webhook handler only):
 //   TELEGRAM_API_KEY — Bot token (used to echo replies to inbound messages)
 
-// ─── Type handlers for /test ──────────────────────────────────────────────────
+// ─── Types supported by the unified send() ────────────────────────────────────
+const UNIFIED_TYPES = new Set([
+  'message',
+  'photo',
+  'video',
+  'audio',
+  'document',
+  'voice',
+  'video_note',
+  'sticker',
+  'animation',
+  'location',
+  'venue',
+  'contact',
+  'poll',
+  'dice',
+]);
 
-async function handleTestType(
+// ─── Handle types NOT in the unified service (need messageId, fromChatId, etc.) ─
+async function handleNonUnifiedType(
   type: string,
   token: string,
   chatId: string,
@@ -51,50 +57,8 @@ async function handleTestType(
   const opts = p as unknown as TelegramMessageOpts;
 
   switch (type) {
-    case 'message':
-      return sendMessage(token, chatId, String(p.text ?? ''), opts);
-
-    case 'photo':
-      return sendPhoto(token, chatId, String(p.photo ?? ''), opts);
-
-    case 'video':
-      return sendVideo(token, chatId, String(p.video ?? ''), opts);
-
-    case 'audio':
-      return sendAudio(token, chatId, String(p.audio ?? ''), opts);
-
-    case 'document':
-      return sendDocument(token, chatId, String(p.document ?? ''), opts);
-
-    case 'voice':
-      return sendVoice(token, chatId, String(p.voice ?? ''), opts);
-
-    case 'video_note':
-      return sendVideoNote(token, chatId, String(p.video_note ?? ''), opts);
-
-    case 'sticker':
-      return sendSticker(token, chatId, String(p.sticker ?? ''), opts);
-
-    case 'animation':
-      return sendAnimation(token, chatId, String(p.animation ?? ''), opts);
-
     case 'media_group':
       return sendMediaGroup(token, chatId, (p.media as MediaGroupItem[]) ?? [], opts);
-
-    case 'location':
-      return sendLocation(token, chatId, Number(p.latitude), Number(p.longitude), opts);
-
-    case 'venue':
-      return sendVenue(token, chatId, p.venue as VenueData, opts);
-
-    case 'contact':
-      return sendContact(token, chatId, p.contact as ContactData, opts);
-
-    case 'poll':
-      return sendPoll(token, chatId, String(p.question ?? ''), (p.options as string[]) ?? [], opts);
-
-    case 'dice':
-      return sendDice(token, chatId, typeof p.emoji === 'string' ? p.emoji : '🎲', opts);
 
     case 'chat_action':
       return sendChatAction(token, chatId, String(p.action ?? 'typing'), opts);
@@ -252,8 +216,8 @@ export default express
   })
 
   // ── POST /api/sample-api/telegram/send ────────────────────────────────────
-  // Simple text send. Body: { to, message, configLabel? }
-  // Requires authenticated user with tenant_id for credential resolution.
+  // Simple text send via unified comms service.
+  // Body: { to, message, configLabel? }
   .post('/send', async (req: Request, res: Response) => {
     const { to, message, configLabel } = req.body as { to?: string; message?: string; configLabel?: string };
     if (!to || !message) {
@@ -266,10 +230,15 @@ export default express
         res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
         return;
       }
-      const config = await resolveCommsCredentials(tenantId, 'telegram', configLabel);
-      const token = config.credentials.bot_token;
-      await sendMessage(token, to, message);
-      res.json({ ok: true });
+      const result = await send({
+        tenantId,
+        configLabel,
+        channel: 'telegram',
+        to,
+        type: 'text',
+        payload: { text: message },
+      });
+      res.json({ ok: result.success, result });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }
@@ -278,8 +247,7 @@ export default express
   // ── POST /api/sample-api/telegram/test ────────────────────────────────────
   // Multi-type test dispatcher.
   // Body: { type, to, configLabel?, ...type-specific fields }
-  // Requires authenticated user with tenant_id for credential resolution.
-  // See TelegramTest.vue for sample payloads per type.
+  // Types in the unified service go through send(). Others use direct library calls.
   .post('/test', async (req: Request, res: Response) => {
     const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
     if (!tenantId) {
@@ -288,17 +256,6 @@ export default express
     }
 
     const { type, to, configLabel, ...p } = req.body as Record<string, unknown>;
-
-    let token: string;
-    try {
-      const config = await resolveCommsCredentials(tenantId, 'telegram', configLabel as string | undefined);
-      token = config.credentials.bot_token;
-    } catch (err: unknown) {
-      res
-        .status(500)
-        .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve Telegram credentials' });
-      return;
-    }
 
     if (!type || typeof type !== 'string') {
       res.status(400).json({ ok: false, error: 'type is required' });
@@ -310,13 +267,78 @@ export default express
       return;
     }
 
+    const chatId = String(to);
+
     try {
-      const chatId = String(to);
-      const result = await handleTestType(type, token, chatId, p, res);
-      if (result === null) return;
-      res.json({ ok: true, result });
+      // Map test page type names to unified service type names
+      const unifiedType = type === 'message' ? 'text' : type;
+
+      if (UNIFIED_TYPES.has(type)) {
+        // Use unified send() — handles credential resolution internally
+        const result = await send({
+          tenantId,
+          configLabel: configLabel as string | undefined,
+          channel: 'telegram',
+          to: chatId,
+          type: unifiedType,
+          payload: p,
+        });
+        if (!result.success) {
+          res.status(500).json({ ok: false, error: result.error });
+          return;
+        }
+        res.json({ ok: true, result });
+      } else {
+        // Non-unified types — resolve credentials manually, call library directly
+        const { resolveCommsCredentials } = await import('@common/node/comms/tenant/resolver');
+        const config = await resolveCommsCredentials(tenantId, 'telegram', configLabel as string | undefined);
+        const token = config.credentials.bot_token;
+
+        const result = await handleNonUnifiedType(type, token, chatId, p, res);
+        if (result === null) return; // response already sent by handler
+        res.json({ ok: true, result });
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An unexpected error occurred';
       res.status(500).json({ ok: false, error: message });
+    }
+  })
+
+  // ── POST /api/sample-api/telegram/broadcast ───────────────────────────────
+  // Send the same message to multiple recipients.
+  // Body: { recipients: string[], type, configLabel?, payload }
+  // Example: { recipients: ["123", "456"], type: "text", payload: { text: "Hello everyone!" } }
+  .post('/broadcast', async (req: Request, res: Response) => {
+    const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const { recipients, type, configLabel, ...payload } = req.body as Record<string, unknown>;
+
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      res.status(400).json({ ok: false, error: 'recipients (array of chatIds) is required' });
+      return;
+    }
+
+    if (!type || typeof type !== 'string') {
+      res.status(400).json({ ok: false, error: 'type is required' });
+      return;
+    }
+
+    try {
+      const result = await broadcast({
+        tenantId,
+        configLabel: configLabel as string | undefined,
+        channel: 'telegram',
+        recipients: recipients as string[],
+        type: type === 'message' ? 'text' : type,
+        payload,
+        options: { mode: 'sequential', delayMs: 100 },
+      });
+      res.json({ ok: result.success, result });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }
   });

--- a/apps/sample-api/src/telegram/routes.ts
+++ b/apps/sample-api/src/telegram/routes.ts
@@ -1,0 +1,278 @@
+import { handleUpdate } from '@common/node/comms/telegram2/inbound';
+import {
+  copyMessage,
+  deleteMessage,
+  editMessageCaption,
+  editMessageReplyMarkup,
+  editMessageText,
+  forwardMessage,
+  pinMessage,
+  sendAnimation,
+  sendAudio,
+  sendChatAction,
+  sendContact,
+  sendDice,
+  sendDocument,
+  sendLocation,
+  sendMediaGroup,
+  sendMessage,
+  sendPhoto,
+  sendPoll,
+  sendSticker,
+  sendVenue,
+  sendVideo,
+  sendVideoNote,
+  sendVoice,
+  unpinMessage,
+} from '@common/node/comms/telegram2/outbound';
+import type { ContactData, MediaGroupItem, TelegramMessageOpts, VenueData } from '@common/node/comms/telegram2/types';
+import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
+import type { Request, Response } from 'express';
+import express from 'express';
+
+// Telegram Bot API test dispatcher
+// Docs: https://core.telegram.org/bots/api/
+//
+// Credentials are resolved per-tenant from the database via resolveCommsCredentials().
+// Each tenant must configure their own Telegram Bot Token in the Comms Config page.
+//
+// Required env var (for the inbound webhook handler only):
+//   TELEGRAM_API_KEY — Bot token (used to echo replies to inbound messages)
+
+// ─── Type handlers for /test ──────────────────────────────────────────────────
+
+async function handleTestType(
+  type: string,
+  token: string,
+  chatId: string,
+  p: Record<string, unknown>,
+  res: Response,
+): Promise<unknown> {
+  const opts = p as unknown as TelegramMessageOpts;
+
+  switch (type) {
+    case 'message':
+      return sendMessage(token, chatId, String(p.text ?? ''), opts);
+
+    case 'photo':
+      return sendPhoto(token, chatId, String(p.photo ?? ''), opts);
+
+    case 'video':
+      return sendVideo(token, chatId, String(p.video ?? ''), opts);
+
+    case 'audio':
+      return sendAudio(token, chatId, String(p.audio ?? ''), opts);
+
+    case 'document':
+      return sendDocument(token, chatId, String(p.document ?? ''), opts);
+
+    case 'voice':
+      return sendVoice(token, chatId, String(p.voice ?? ''), opts);
+
+    case 'video_note':
+      return sendVideoNote(token, chatId, String(p.video_note ?? ''), opts);
+
+    case 'sticker':
+      return sendSticker(token, chatId, String(p.sticker ?? ''), opts);
+
+    case 'animation':
+      return sendAnimation(token, chatId, String(p.animation ?? ''), opts);
+
+    case 'media_group':
+      return sendMediaGroup(token, chatId, (p.media as MediaGroupItem[]) ?? [], opts);
+
+    case 'location':
+      return sendLocation(token, chatId, Number(p.latitude), Number(p.longitude), opts);
+
+    case 'venue':
+      return sendVenue(token, chatId, p.venue as VenueData, opts);
+
+    case 'contact':
+      return sendContact(token, chatId, p.contact as ContactData, opts);
+
+    case 'poll':
+      return sendPoll(token, chatId, String(p.question ?? ''), (p.options as string[]) ?? [], opts);
+
+    case 'dice':
+      return sendDice(token, chatId, typeof p.emoji === 'string' ? p.emoji : '🎲', opts);
+
+    case 'chat_action':
+      return sendChatAction(token, chatId, String(p.action ?? 'typing'), opts);
+
+    case 'forward': {
+      if (!p.from_chat_id || !p.message_id) {
+        res.status(400).json({ ok: false, error: 'from_chat_id and message_id are required for forward' });
+        return null;
+      }
+      return forwardMessage(token, chatId, String(p.from_chat_id), Number(p.message_id), opts);
+    }
+
+    case 'copy': {
+      if (!p.from_chat_id || !p.message_id) {
+        res.status(400).json({ ok: false, error: 'from_chat_id and message_id are required for copy' });
+        return null;
+      }
+      return copyMessage(token, chatId, String(p.from_chat_id), Number(p.message_id), opts);
+    }
+
+    case 'edit_text': {
+      if (!p.message_id) {
+        res.status(400).json({ ok: false, error: 'message_id is required for edit_text' });
+        return null;
+      }
+      return editMessageText(token, chatId, Number(p.message_id), String(p.text ?? ''), opts);
+    }
+
+    case 'edit_caption': {
+      if (!p.message_id) {
+        res.status(400).json({ ok: false, error: 'message_id is required for edit_caption' });
+        return null;
+      }
+      return editMessageCaption(token, chatId, Number(p.message_id), String(p.caption ?? ''), opts);
+    }
+
+    case 'edit_markup': {
+      if (!p.message_id || !p.reply_markup) {
+        res.status(400).json({ ok: false, error: 'message_id and reply_markup are required for edit_markup' });
+        return null;
+      }
+      return editMessageReplyMarkup(token, chatId, Number(p.message_id), String(p.reply_markup));
+    }
+
+    case 'delete': {
+      if (!p.message_id) {
+        res.status(400).json({ ok: false, error: 'message_id is required for delete' });
+        return null;
+      }
+      return deleteMessage(token, chatId, Number(p.message_id));
+    }
+
+    case 'pin': {
+      if (!p.message_id) {
+        res.status(400).json({ ok: false, error: 'message_id is required for pin' });
+        return null;
+      }
+      return pinMessage(token, chatId, Number(p.message_id), opts);
+    }
+
+    case 'unpin': {
+      if (!p.message_id) {
+        res.status(400).json({ ok: false, error: 'message_id is required for unpin' });
+        return null;
+      }
+      return unpinMessage(token, chatId, Number(p.message_id));
+    }
+
+    default:
+      res.status(400).json({ ok: false, error: `Unknown type: ${type}` });
+      return null;
+  }
+}
+
+export default express
+  .Router()
+
+  // ── POST /api/sample-api/telegram/webhook ──────────────────────────────────
+  // Telegram sends every update here as a POST.
+  // Respond 200 immediately — Telegram will retry if you don't.
+  // Uses TELEGRAM_API_KEY env var for bot replies (not tenant-scoped).
+  // To register this webhook URL with Telegram, call:
+  //   POST https://api.telegram.org/bot<TOKEN>/setWebhook
+  //   Body: { url: "https://yourdomain.com/api/sample-api/telegram/webhook" }
+  .post('/webhook', async (req, res) => {
+    res.sendStatus(200); // always ack first
+
+    const token = process.env.TELEGRAM_API_KEY;
+    if (!token) return;
+
+    const parsed = handleUpdate(req.body);
+    if (!parsed || parsed.updateType !== 'message') return;
+
+    // biome-ignore lint/suspicious/noExplicitAny: parsed data shape varies by updateType
+    const data = parsed.data as any;
+    if (!data?.content || data.content.type !== 'text') return;
+
+    const chatId = String(data.chat?.id ?? '');
+    const userText = String(data.content.text ?? '')
+      .trim()
+      .toLowerCase();
+
+    let reply: string;
+    if (userText === 'hello' || userText === 'hi') {
+      reply = 'Hi! What can I help you with?';
+    } else {
+      reply = `You said: "${data.content.text}". (This bot is a work in progress.)`;
+    }
+
+    await sendMessage(token, chatId, reply);
+  })
+
+  // ── POST /api/sample-api/telegram/send ────────────────────────────────────
+  // Simple text send. Body: { to, message, configLabel? }
+  // Requires authenticated user with tenant_id for credential resolution.
+  .post('/send', async (req: Request, res: Response) => {
+    const { to, message, configLabel } = req.body as { to?: string; message?: string; configLabel?: string };
+    if (!to || !message) {
+      res.status(400).json({ ok: false, error: 'to (chatId) and message are required' });
+      return;
+    }
+    try {
+      const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+      if (!tenantId) {
+        res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+        return;
+      }
+      const config = await resolveCommsCredentials(tenantId, 'telegram', configLabel);
+      const token = config.credentials.bot_token;
+      await sendMessage(token, to, message);
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  })
+
+  // ── POST /api/sample-api/telegram/test ────────────────────────────────────
+  // Multi-type test dispatcher.
+  // Body: { type, to, configLabel?, ...type-specific fields }
+  // Requires authenticated user with tenant_id for credential resolution.
+  // See TelegramTest.vue for sample payloads per type.
+  .post('/test', async (req: Request, res: Response) => {
+    const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const { type, to, configLabel, ...p } = req.body as Record<string, unknown>;
+
+    let token: string;
+    try {
+      const config = await resolveCommsCredentials(tenantId, 'telegram', configLabel as string | undefined);
+      token = config.credentials.bot_token;
+    } catch (err: unknown) {
+      res
+        .status(500)
+        .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve Telegram credentials' });
+      return;
+    }
+
+    if (!type || typeof type !== 'string') {
+      res.status(400).json({ ok: false, error: 'type is required' });
+      return;
+    }
+
+    if (!to) {
+      res.status(400).json({ ok: false, error: 'to (chatId) is required' });
+      return;
+    }
+
+    try {
+      const chatId = String(to);
+      const result = await handleTestType(type, token, chatId, p, res);
+      if (result === null) return;
+      res.json({ ok: true, result });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+      res.status(500).json({ ok: false, error: message });
+    }
+  });

--- a/apps/sample-api/src/tenant-comms/routes.ts
+++ b/apps/sample-api/src/tenant-comms/routes.ts
@@ -10,7 +10,7 @@
 //   POST   /tenant-comms/:id/register-webhook — manually (re-)register Telegram webhook
 
 import { randomBytes } from 'node:crypto';
-import { deleteWebhook, setWebhook } from '@common/node/comms/telegram2/outbound';
+import { deleteWebhook, setWebhook } from '@common/node/comms/telegram2/inbound';
 import { decryptCredentials, encryptCredentials } from '@common/node/comms/tenant/crypto';
 import type { CommsChannel, CommsProvider } from '@common/node/comms/tenant/types';
 import * as realServices from '@common/node/services';

--- a/apps/sample-api/src/tenant-comms/routes.ts
+++ b/apps/sample-api/src/tenant-comms/routes.ts
@@ -81,6 +81,7 @@ export default express
 
       const result = configs.map(c => ({
         id: c.id,
+        label: c.label,
         channel: c.channel,
         provider: c.provider,
         credentials: maskCredentials(c.credentials),
@@ -128,6 +129,7 @@ export default express
         ok: true,
         data: {
           id: config.id,
+          label: config.label,
           channel: config.channel,
           provider: config.provider,
           credentials: maskCredentials(config.credentials),
@@ -152,7 +154,8 @@ export default express
       return;
     }
 
-    const { channel, provider, credentials, senderIdentity } = req.body as {
+    const { label, channel, provider, credentials, senderIdentity } = req.body as {
+      label?: string;
       channel?: string;
       provider?: string;
       credentials?: Record<string, string>;
@@ -160,6 +163,19 @@ export default express
     };
 
     // Validation
+    if (!label || typeof label !== 'string' || label.trim().length === 0) {
+      res.status(400).json({ ok: false, error: 'label is required (e.g. "support-wa", "marketing-email")' });
+      return;
+    }
+    const labelSlug = label.trim().toLowerCase().replace(/\s+/g, '-');
+    if ((!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(labelSlug) && labelSlug.length > 1) || labelSlug.length === 0) {
+      res.status(400).json({
+        ok: false,
+        error:
+          'label must be slug format: lowercase letters, numbers, and hyphens only (e.g. "support-wa", "marketing-email"). No spaces or special characters.',
+      });
+      return;
+    }
     if (!channel || !validateChannel(channel)) {
       res
         .status(400)
@@ -182,7 +198,7 @@ export default express
     }
 
     try {
-      // Check for existing config (unique constraint: tenant_id + channel + provider)
+      // Check for existing config with same tenant_id + channel + label
       const [existing] = await db()
         .select({ id: tenantCommsConfig.id })
         .from(tenantCommsConfig)
@@ -190,7 +206,7 @@ export default express
           and(
             eq(tenantCommsConfig.tenant_id, tenantId),
             eq(tenantCommsConfig.channel, channel),
-            eq(tenantCommsConfig.provider, provider),
+            eq(tenantCommsConfig.label, labelSlug),
           ),
         )
         .limit(1);
@@ -198,7 +214,7 @@ export default express
       if (existing) {
         res.status(409).json({
           ok: false,
-          error: `A ${channel} configuration with provider ${provider} already exists for this tenant. Use PUT to update.`,
+          error: `A ${channel} configuration with label "${labelSlug}" already exists for this tenant. Use a different label or PUT to update.`,
         });
         return;
       }
@@ -210,6 +226,7 @@ export default express
         .insert(tenantCommsConfig)
         .values({
           tenant_id: tenantId,
+          label: labelSlug,
           channel,
           provider,
           credentials: encrypted,

--- a/apps/sample-api/src/tenant-comms/routes.ts
+++ b/apps/sample-api/src/tenant-comms/routes.ts
@@ -1,0 +1,328 @@
+// Tenant Communications Config — Admin CRUD API
+// Allows tenant admins to manage their own communication credentials.
+//
+// Endpoints:
+//   GET    /tenant-comms           — list all channel configs for the authenticated tenant
+//   GET    /tenant-comms/:channel  — get specific channel config (credentials masked)
+//   POST   /tenant-comms           — create a new channel config
+//   PUT    /tenant-comms/:id       — update an existing channel config
+//   DELETE /tenant-comms/:id       — delete a channel config
+
+import { decryptCredentials, encryptCredentials } from '@common/node/comms/tenant/crypto';
+import type { CommsChannel, CommsProvider } from '@common/node/comms/tenant/types';
+import * as realServices from '@common/node/services';
+import { and, eq } from 'drizzle-orm';
+import type { Request, Response } from 'express';
+import express from 'express';
+import { tenantCommsConfig } from '../database/schema-iam.ts';
+
+// biome-ignore lint/suspicious/noExplicitAny: services interface varies by store type
+const services: any = realServices;
+const db = () => services.get('drizzle1');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Mask a credential string — show only last 4 chars */
+function maskCredential(value: string): string {
+  if (value.length <= 4) return '****';
+  return '*'.repeat(value.length - 4) + value.slice(-4);
+}
+
+/** Mask all credential values in an object */
+function maskCredentials(encrypted: string): Record<string, string> {
+  try {
+    const decrypted = decryptCredentials(encrypted);
+    const masked: Record<string, string> = {};
+    for (const [key, value] of Object.entries(decrypted)) {
+      masked[key] = maskCredential(value);
+    }
+    return masked;
+  } catch {
+    return { error: '****' };
+  }
+}
+
+/** Extract tenant_id from authenticated user. Falls back to 1 in development. */
+function getTenantId(req: Request): number | null {
+  const user = (req as any).user;
+  return user?.tenant_id ?? user?.tenantId ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+const VALID_CHANNELS: CommsChannel[] = ['telegram', 'email', 'whatsapp', 'sms'];
+const VALID_PROVIDERS: CommsProvider[] = ['telegram', 'sendgrid', 'meta', 'nexmo'];
+
+function validateChannel(channel: string): channel is CommsChannel {
+  return VALID_CHANNELS.includes(channel as CommsChannel);
+}
+
+function validateProvider(provider: string): provider is CommsProvider {
+  return VALID_PROVIDERS.includes(provider as CommsProvider);
+}
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+export default express
+  .Router()
+
+  // ── GET /tenant-comms ─────────────────────────────────────────────────────
+  // List all channel configs for the authenticated tenant.
+  // Credentials are masked in the response.
+  .get('/', async (req: Request, res: Response) => {
+    const tenantId = getTenantId(req);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    try {
+      const configs = await db().select().from(tenantCommsConfig).where(eq(tenantCommsConfig.tenant_id, tenantId));
+
+      const result = configs.map(c => ({
+        id: c.id,
+        channel: c.channel,
+        provider: c.provider,
+        credentials: maskCredentials(c.credentials),
+        senderIdentity: c.sender_identity,
+        isActive: c.is_active,
+        createdAt: c.created_at,
+        updatedAt: c.updated_at,
+      }));
+
+      res.json({ ok: true, data: result });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  })
+
+  // ── GET /tenant-comms/:channel ────────────────────────────────────────────
+  // Get a specific channel config for the authenticated tenant.
+  // Credentials are masked in the response.
+  .get('/:channel', async (req: Request, res: Response) => {
+    const tenantId = getTenantId(req);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const { channel } = req.params;
+    if (!validateChannel(channel)) {
+      res.status(400).json({ ok: false, error: `Invalid channel. Must be one of: ${VALID_CHANNELS.join(', ')}` });
+      return;
+    }
+
+    try {
+      const [config] = await db()
+        .select()
+        .from(tenantCommsConfig)
+        .where(and(eq(tenantCommsConfig.tenant_id, tenantId), eq(tenantCommsConfig.channel, channel)))
+        .limit(1);
+
+      if (!config) {
+        res.status(404).json({ ok: false, error: `No ${channel} configuration found for this tenant` });
+        return;
+      }
+
+      res.json({
+        ok: true,
+        data: {
+          id: config.id,
+          channel: config.channel,
+          provider: config.provider,
+          credentials: maskCredentials(config.credentials),
+          senderIdentity: config.sender_identity,
+          isActive: config.is_active,
+          createdAt: config.created_at,
+          updatedAt: config.updated_at,
+        },
+      });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  })
+
+  // ── POST /tenant-comms ────────────────────────────────────────────────────
+  // Create a new channel config for the authenticated tenant.
+  // Body: { channel, provider, credentials: {...}, senderIdentity: {...} }
+  .post('/', async (req: Request, res: Response) => {
+    const tenantId = getTenantId(req);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const { channel, provider, credentials, senderIdentity } = req.body as {
+      channel?: string;
+      provider?: string;
+      credentials?: Record<string, string>;
+      senderIdentity?: Record<string, string>;
+    };
+
+    // Validation
+    if (!channel || !validateChannel(channel)) {
+      res
+        .status(400)
+        .json({ ok: false, error: `channel is required and must be one of: ${VALID_CHANNELS.join(', ')}` });
+      return;
+    }
+    if (!provider || !validateProvider(provider)) {
+      res
+        .status(400)
+        .json({ ok: false, error: `provider is required and must be one of: ${VALID_PROVIDERS.join(', ')}` });
+      return;
+    }
+    if (!credentials || typeof credentials !== 'object' || Object.keys(credentials).length === 0) {
+      res.status(400).json({ ok: false, error: 'credentials object is required and must not be empty' });
+      return;
+    }
+    if (!senderIdentity || typeof senderIdentity !== 'object') {
+      res.status(400).json({ ok: false, error: 'senderIdentity object is required' });
+      return;
+    }
+
+    try {
+      // Check for existing config (unique constraint: tenant_id + channel + provider)
+      const [existing] = await db()
+        .select({ id: tenantCommsConfig.id })
+        .from(tenantCommsConfig)
+        .where(
+          and(
+            eq(tenantCommsConfig.tenant_id, tenantId),
+            eq(tenantCommsConfig.channel, channel),
+            eq(tenantCommsConfig.provider, provider),
+          ),
+        )
+        .limit(1);
+
+      if (existing) {
+        res.status(409).json({
+          ok: false,
+          error: `A ${channel} configuration with provider ${provider} already exists for this tenant. Use PUT to update.`,
+        });
+        return;
+      }
+
+      // Encrypt credentials before storing
+      const encrypted = encryptCredentials(credentials);
+
+      const [created] = await db()
+        .insert(tenantCommsConfig)
+        .values({
+          tenant_id: tenantId,
+          channel,
+          provider,
+          credentials: encrypted,
+          sender_identity: senderIdentity,
+          is_active: true,
+        })
+        .returning({ id: tenantCommsConfig.id });
+
+      res.status(201).json({ ok: true, data: { id: created.id } });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  })
+
+  // ── PUT /tenant-comms/:id ─────────────────────────────────────────────────
+  // Update an existing channel config.
+  // Body: { credentials?: {...}, senderIdentity?: {...}, isActive?: boolean }
+  // Only fields provided will be updated.
+  .put('/:id', async (req: Request, res: Response) => {
+    const tenantId = getTenantId(req);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const id = Number(req.params.id);
+    if (!id || Number.isNaN(id)) {
+      res.status(400).json({ ok: false, error: 'Valid numeric id is required' });
+      return;
+    }
+
+    const { credentials, senderIdentity, isActive } = req.body as {
+      credentials?: Record<string, string>;
+      senderIdentity?: Record<string, string>;
+      isActive?: boolean;
+    };
+
+    try {
+      // Verify ownership — config must belong to this tenant
+      const [existing] = await db()
+        .select({ id: tenantCommsConfig.id, tenant_id: tenantCommsConfig.tenant_id })
+        .from(tenantCommsConfig)
+        .where(eq(tenantCommsConfig.id, id))
+        .limit(1);
+
+      if (!existing) {
+        res.status(404).json({ ok: false, error: 'Configuration not found' });
+        return;
+      }
+      if (existing.tenant_id !== tenantId) {
+        res.status(403).json({ ok: false, error: 'You do not have permission to modify this configuration' });
+        return;
+      }
+
+      // Build update payload
+      const updates: Record<string, unknown> = {
+        updated_at: new Date(),
+      };
+
+      if (credentials && typeof credentials === 'object' && Object.keys(credentials).length > 0) {
+        updates.credentials = encryptCredentials(credentials);
+      }
+      if (senderIdentity && typeof senderIdentity === 'object') {
+        updates.sender_identity = senderIdentity;
+      }
+      if (typeof isActive === 'boolean') {
+        updates.is_active = isActive;
+      }
+
+      await db().update(tenantCommsConfig).set(updates).where(eq(tenantCommsConfig.id, id));
+
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  })
+
+  // ── DELETE /tenant-comms/:id ──────────────────────────────────────────────
+  // Delete a channel config.
+  .delete('/:id', async (req: Request, res: Response) => {
+    const tenantId = getTenantId(req);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const id = Number(req.params.id);
+    if (!id || Number.isNaN(id)) {
+      res.status(400).json({ ok: false, error: 'Valid numeric id is required' });
+      return;
+    }
+
+    try {
+      // Verify ownership
+      const [existing] = await db()
+        .select({ id: tenantCommsConfig.id, tenant_id: tenantCommsConfig.tenant_id })
+        .from(tenantCommsConfig)
+        .where(eq(tenantCommsConfig.id, id))
+        .limit(1);
+
+      if (!existing) {
+        res.status(404).json({ ok: false, error: 'Configuration not found' });
+        return;
+      }
+      if (existing.tenant_id !== tenantId) {
+        res.status(403).json({ ok: false, error: 'You do not have permission to delete this configuration' });
+        return;
+      }
+
+      await db().delete(tenantCommsConfig).where(eq(tenantCommsConfig.id, id));
+
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  });

--- a/apps/sample-api/src/tenant-comms/routes.ts
+++ b/apps/sample-api/src/tenant-comms/routes.ts
@@ -7,7 +7,10 @@
 //   POST   /tenant-comms           — create a new channel config
 //   PUT    /tenant-comms/:id       — update an existing channel config
 //   DELETE /tenant-comms/:id       — delete a channel config
+//   POST   /tenant-comms/:id/register-webhook — manually (re-)register Telegram webhook
 
+import { randomBytes } from 'node:crypto';
+import { deleteWebhook, setWebhook } from '@common/node/comms/telegram2/outbound';
 import { decryptCredentials, encryptCredentials } from '@common/node/comms/tenant/crypto';
 import type { CommsChannel, CommsProvider } from '@common/node/comms/tenant/types';
 import * as realServices from '@common/node/services';
@@ -46,6 +49,39 @@ function maskCredentials(encrypted: string): Record<string, string> {
 function getTenantId(req: Request): number | null {
   const user = (req as any).user;
   return user?.tenant_id ?? user?.tenantId ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+}
+
+/** Generate a URL-safe random secret token (64 chars, A-Za-z0-9_-) for Telegram webhook verification */
+function generateWebhookSecret(): string {
+  return randomBytes(48).toString('base64url').slice(0, 64);
+}
+
+/** Build the full webhook URL for a Telegram config */
+function buildTelegramWebhookUrl(label: string): string {
+  const domain = process.env.APP_DOMAIN || process.env.BASE_URL || '';
+  if (!domain) throw new Error('APP_DOMAIN or BASE_URL env var must be set for Telegram webhook registration');
+  const base = domain.replace(/\/$/, '');
+  return `${base}/api/sample-api/telegram/webhook/${label}`;
+}
+
+/**
+ * Register a Telegram webhook for a config.
+ * Generates webhook_secret if not present, calls Telegram setWebhook API.
+ * Returns the updated credentials with webhook_secret included.
+ */
+async function registerTelegramWebhook(
+  credentials: Record<string, string>,
+  label: string,
+): Promise<{ credentials: Record<string, string>; webhookUrl: string }> {
+  const webhookSecret = credentials.webhook_secret || generateWebhookSecret();
+  const webhookUrl = buildTelegramWebhookUrl(label);
+
+  await setWebhook(credentials.bot_token, webhookUrl, webhookSecret);
+
+  return {
+    credentials: { ...credentials, webhook_secret: webhookSecret },
+    webhookUrl,
+  };
 }
 
 // ─── Validation ───────────────────────────────────────────────────────────────
@@ -235,7 +271,28 @@ export default express
         })
         .returning({ id: tenantCommsConfig.id });
 
-      res.status(201).json({ ok: true, data: { id: created.id } });
+      // Auto-register Telegram webhook after config creation
+      let webhookUrl: string | undefined;
+      if (channel === 'telegram' && credentials.bot_token) {
+        try {
+          const result = await registerTelegramWebhook(credentials, labelSlug);
+          webhookUrl = result.webhookUrl;
+          // Update credentials with the generated webhook_secret
+          await db()
+            .update(tenantCommsConfig)
+            .set({ credentials: encryptCredentials(result.credentials) })
+            .where(eq(tenantCommsConfig.id, created.id));
+        } catch (webhookErr: unknown) {
+          // Webhook registration failed — config is saved but webhook is not active.
+          // User can retry via the register-webhook endpoint.
+          console.warn(
+            'Telegram webhook registration failed:',
+            webhookErr instanceof Error ? webhookErr.message : webhookErr,
+          );
+        }
+      }
+
+      res.status(201).json({ ok: true, data: { id: created.id, webhookUrl } });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }
@@ -321,11 +378,7 @@ export default express
 
     try {
       // Verify ownership
-      const [existing] = await db()
-        .select({ id: tenantCommsConfig.id, tenant_id: tenantCommsConfig.tenant_id })
-        .from(tenantCommsConfig)
-        .where(eq(tenantCommsConfig.id, id))
-        .limit(1);
+      const [existing] = await db().select().from(tenantCommsConfig).where(eq(tenantCommsConfig.id, id)).limit(1);
 
       if (!existing) {
         res.status(404).json({ ok: false, error: 'Configuration not found' });
@@ -336,9 +389,80 @@ export default express
         return;
       }
 
+      // Unregister Telegram webhook before deleting config
+      if (existing.channel === 'telegram') {
+        try {
+          const creds = decryptCredentials(existing.credentials);
+          if (creds.bot_token) {
+            await deleteWebhook(creds.bot_token);
+          }
+        } catch (webhookErr: unknown) {
+          console.warn(
+            'Telegram webhook deletion failed (proceeding with config delete):',
+            webhookErr instanceof Error ? webhookErr.message : webhookErr,
+          );
+        }
+      }
+
       await db().delete(tenantCommsConfig).where(eq(tenantCommsConfig.id, id));
 
       res.json({ ok: true });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
+    }
+  })
+
+  // ── POST /tenant-comms/:id/register-webhook ───────────────────────────────
+  // Manually (re-)register the Telegram webhook for a config.
+  // Useful if auto-registration failed or if APP_DOMAIN changed.
+  .post('/:id/register-webhook', async (req: Request, res: Response) => {
+    const tenantId = getTenantId(req);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const id = Number(req.params.id);
+    if (!id || Number.isNaN(id)) {
+      res.status(400).json({ ok: false, error: 'Valid numeric id is required' });
+      return;
+    }
+
+    try {
+      // Verify ownership and get config
+      const [existing] = await db().select().from(tenantCommsConfig).where(eq(tenantCommsConfig.id, id)).limit(1);
+
+      if (!existing) {
+        res.status(404).json({ ok: false, error: 'Configuration not found' });
+        return;
+      }
+      if (existing.tenant_id !== tenantId) {
+        res.status(403).json({ ok: false, error: 'You do not have permission to modify this configuration' });
+        return;
+      }
+      if (existing.channel !== 'telegram') {
+        res.status(400).json({ ok: false, error: 'Webhook registration is only supported for Telegram configs' });
+        return;
+      }
+
+      const credentials = decryptCredentials(existing.credentials);
+      if (!credentials.bot_token) {
+        res.status(400).json({ ok: false, error: 'bot_token is missing from credentials' });
+        return;
+      }
+
+      const result = await registerTelegramWebhook(credentials, existing.label);
+
+      // Update credentials with (possibly new) webhook_secret
+      await db()
+        .update(tenantCommsConfig)
+        .set({
+          credentials: encryptCredentials(result.credentials),
+          updated_at: new Date(),
+        })
+        .where(eq(tenantCommsConfig.id, id));
+
+      res.json({ ok: true, data: { webhookUrl: result.webhookUrl } });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }

--- a/apps/sample-api/src/whatsapp/routes.ts
+++ b/apps/sample-api/src/whatsapp/routes.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import { parseWebhook } from '@common/node/comms/whatsapp2/inbound';
 import {
   getMediaUrl,
@@ -222,7 +223,8 @@ export default express
   })
 
   // ── POST /api/sample-api/whatsapp/send ──────────────────────────────────────
-  // Simple text send — no auth. Body: { to, message }
+  // Simple text send. Body: { to, message }
+  // Requires authenticated user with tenant_id for credential resolution.
   .post('/send', async (req: Request, res: Response) => {
     const { to, message } = req.body as { to?: string; message?: string };
     if (!to || !message) {
@@ -230,11 +232,14 @@ export default express
       return;
     }
     try {
-      const { WHATSAPP_TOKEN: token = '', WHATSAPP_PHONE_NUMBER_ID: phoneId = '' } = process.env;
-      if (!token || !phoneId) {
-        res.status(500).json({ ok: false, error: 'WHATSAPP_TOKEN or WHATSAPP_PHONE_NUMBER_ID not set' });
+      const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+      if (!tenantId) {
+        res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
         return;
       }
+      const config = await resolveCommsCredentials(tenantId, 'whatsapp');
+      const token = config.credentials.token;
+      const phoneId = config.senderIdentity.phone_number_id;
       await sendText(token, phoneId, to, message);
       res.json({ ok: true });
     } catch (err: unknown) {
@@ -243,14 +248,27 @@ export default express
   })
 
   // ── POST /api/sample-api/whatsapp/test ──────────────────────────────────────
-  // Multi-type test dispatcher — no auth.
+  // Multi-type test dispatcher.
   // Body: { type, to, ...type-specific fields }
+  // Requires authenticated user with tenant_id for credential resolution.
   // See WhatsAppTest.vue for sample payloads per type.
   .post('/test', async (req: Request, res: Response) => {
-    const { WHATSAPP_TOKEN: token = '', WHATSAPP_PHONE_NUMBER_ID: phoneId = '' } = process.env;
+    const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
 
-    if (!token || !phoneId) {
-      res.status(500).json({ ok: false, error: 'WHATSAPP_TOKEN or WHATSAPP_PHONE_NUMBER_ID not set' });
+    let token: string;
+    let phoneId: string;
+    try {
+      const config = await resolveCommsCredentials(tenantId, 'whatsapp');
+      token = config.credentials.token;
+      phoneId = config.senderIdentity.phone_number_id;
+    } catch (err: unknown) {
+      res
+        .status(500)
+        .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve WhatsApp credentials' });
       return;
     }
 

--- a/apps/sample-api/src/whatsapp/routes.ts
+++ b/apps/sample-api/src/whatsapp/routes.ts
@@ -1,9 +1,8 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
 import { broadcast } from '@common/node/comms/service/broadcast';
 import { send } from '@common/node/comms/service/send';
 import type { SendRequest } from '@common/node/comms/service/types';
 import { resolveCommsConfigByIdentity, resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
-import { parseWebhook } from '@common/node/comms/whatsapp2/inbound';
+import { parseWebhook, verifyWebhookSignature } from '@common/node/comms/whatsapp2/inbound';
 import {
   getMediaUrl,
   markAsRead,
@@ -24,17 +23,6 @@ import express from 'express';
 //   - Signature verification uses per-config app_secret (from credentials)
 //   - Webhook verification (GET) checks verify_token against all stored configs
 //   - Falls back to env vars (WHATSAPP_APP_SECRET, WHATSAPP_VERIFY_TOKEN) for backward compat
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/** Verify HMAC-SHA256 signature from Meta webhook */
-function verifySignature(appSecret: string, rawBody: Buffer, signatureHeader: string): boolean {
-  const expected = `sha256=${createHmac('sha256', appSecret).update(rawBody).digest('hex')}`;
-  const sigBuf = Buffer.from(signatureHeader);
-  const expBuf = Buffer.from(expected);
-  if (sigBuf.length !== expBuf.length) return false;
-  return timingSafeEqual(sigBuf, expBuf);
-}
 
 // ─── Types supported by the unified send() ────────────────────────────────────
 const UNIFIED_TYPES = new Set([
@@ -157,7 +145,7 @@ export default express
       // Verify signature using config's app_secret
       const appSecret = config.credentials.app_secret;
       if (appSecret && rawBody) {
-        if (!verifySignature(appSecret, rawBody, signatureHeader)) {
+        if (!verifyWebhookSignature(appSecret, rawBody, signatureHeader)) {
           console.error('WA webhook: signature verification failed for config', config.label);
           return;
         }
@@ -191,7 +179,7 @@ export default express
     // Fallback: legacy env-var based handling (backward compatibility)
     const legacyAppSecret = process.env.WHATSAPP_APP_SECRET;
     if (legacyAppSecret && rawBody) {
-      if (!verifySignature(legacyAppSecret, rawBody, signatureHeader)) {
+      if (!verifyWebhookSignature(legacyAppSecret, rawBody, signatureHeader)) {
         console.error('WA webhook: legacy signature verification failed');
         return;
       }

--- a/apps/sample-api/src/whatsapp/routes.ts
+++ b/apps/sample-api/src/whatsapp/routes.ts
@@ -226,7 +226,7 @@ export default express
   // Simple text send. Body: { to, message }
   // Requires authenticated user with tenant_id for credential resolution.
   .post('/send', async (req: Request, res: Response) => {
-    const { to, message } = req.body as { to?: string; message?: string };
+    const { to, message, configLabel } = req.body as { to?: string; message?: string; configLabel?: string };
     if (!to || !message) {
       res.status(400).json({ ok: false, error: 'to and message are required' });
       return;
@@ -237,7 +237,7 @@ export default express
         res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
         return;
       }
-      const config = await resolveCommsCredentials(tenantId, 'whatsapp');
+      const config = await resolveCommsCredentials(tenantId, 'whatsapp', configLabel);
       const token = config.credentials.token;
       const phoneId = config.senderIdentity.phone_number_id;
       await sendText(token, phoneId, to, message);
@@ -259,10 +259,12 @@ export default express
       return;
     }
 
+    const { type, to, configLabel, ...p } = req.body as Record<string, unknown>;
+
     let token: string;
     let phoneId: string;
     try {
-      const config = await resolveCommsCredentials(tenantId, 'whatsapp');
+      const config = await resolveCommsCredentials(tenantId, 'whatsapp', configLabel as string | undefined);
       token = config.credentials.token;
       phoneId = config.senderIdentity.phone_number_id;
     } catch (err: unknown) {
@@ -271,8 +273,6 @@ export default express
         .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve WhatsApp credentials' });
       return;
     }
-
-    const { type, to, ...p } = req.body as Record<string, unknown>;
 
     if (!type || typeof type !== 'string') {
       res.status(400).json({ ok: false, error: 'type is required' });

--- a/apps/sample-api/src/whatsapp/routes.ts
+++ b/apps/sample-api/src/whatsapp/routes.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { broadcast } from '@common/node/comms/service/broadcast';
 import { send } from '@common/node/comms/service/send';
+import type { SendRequest } from '@common/node/comms/service/types';
 import { resolveCommsConfigByIdentity, resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import { parseWebhook } from '@common/node/comms/whatsapp2/inbound';
 import {
@@ -10,6 +11,7 @@ import {
   sendText,
   sendTypingIndicator,
 } from '@common/node/comms/whatsapp2/outbound';
+import type { WaInboundText } from '@common/node/comms/whatsapp2/types';
 import type { Request, Response } from 'express';
 import express from 'express';
 
@@ -171,14 +173,15 @@ export default express
       // Only handle inbound text messages for now
       if (msg.content.type !== 'text') return;
 
-      const userText = msg.content.body.trim().toLowerCase();
+      const textContent = msg.content as WaInboundText;
+      const userText = textContent.body.trim().toLowerCase();
 
       // Simple echo / greeting handler — extend or replace with AI/service layer
       let reply: string;
       if (userText === 'hello' || userText === 'hi') {
         reply = 'Hi! What can I help you with?';
       } else {
-        reply = `You said: "${msg.content.body}". (This bot is a work in progress.)`;
+        reply = `You said: "${textContent.body}". (This bot is a work in progress.)`;
       }
 
       await sendText(token, phoneId, msg.from, reply);
@@ -201,12 +204,13 @@ export default express
     const msg = messages[0];
     if (msg.content.type !== 'text') return;
 
-    const userText = msg.content.body.trim().toLowerCase();
+    const textContent = msg.content as WaInboundText;
+    const userText = textContent.body.trim().toLowerCase();
     let reply: string;
     if (userText === 'hello' || userText === 'hi') {
       reply = 'Hi! What can I help you with?';
     } else {
-      reply = `You said: "${msg.content.body}". (This bot is a work in progress.)`;
+      reply = `You said: "${textContent.body}". (This bot is a work in progress.)`;
     }
 
     await sendText(legacyToken, legacyPhoneId, msg.from, reply);
@@ -276,7 +280,7 @@ export default express
           to: dest,
           type,
           payload: p,
-        });
+        } as unknown as SendRequest);
         if (!result.success) {
           res.status(500).json({ ok: false, error: result.error });
           return;
@@ -330,7 +334,7 @@ export default express
         type,
         payload,
         options: { mode: 'sequential', delayMs: 1000 },
-      });
+      } as unknown as Parameters<typeof broadcast>[0]);
       res.json({ ok: result.success, result });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });

--- a/apps/sample-api/src/whatsapp/routes.ts
+++ b/apps/sample-api/src/whatsapp/routes.ts
@@ -1,36 +1,15 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { broadcast } from '@common/node/comms/service/broadcast';
+import { send } from '@common/node/comms/service/send';
 import { resolveCommsConfigByIdentity, resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import { parseWebhook } from '@common/node/comms/whatsapp2/inbound';
 import {
   getMediaUrl,
   markAsRead,
-  sendAddressRequest,
-  sendAudio,
-  sendButtons,
-  sendContacts,
-  sendCtaUrlButton,
-  sendDocument,
-  sendFlow,
-  sendImage,
-  sendList,
-  sendLocation,
   sendReaction,
-  sendSticker,
-  sendTemplate,
   sendText,
   sendTypingIndicator,
-  sendVideo,
 } from '@common/node/comms/whatsapp2/outbound';
-import type {
-  WaAddressRequestOpts,
-  WaButtonsOpts,
-  WaContact,
-  WaCtaUrlOpts,
-  WaFlowOpts,
-  WaListOpts,
-  WaMediaInput,
-  WaTemplateOpts,
-} from '@common/node/comms/whatsapp2/types';
 import type { Request, Response } from 'express';
 import express from 'express';
 
@@ -55,41 +34,26 @@ function verifySignature(appSecret: string, rawBody: Buffer, signatureHeader: st
   return timingSafeEqual(sigBuf, expBuf);
 }
 
-function mediaFrom(p: Record<string, unknown>): WaMediaInput {
-  if (typeof p.id === 'string') return { id: p.id };
-  if (typeof p.link === 'string') return { link: p.link };
-  throw new Error('Either id or link is required for media');
-}
+// ─── Types supported by the unified send() ────────────────────────────────────
+const UNIFIED_TYPES = new Set([
+  'text',
+  'image',
+  'audio',
+  'video',
+  'document',
+  'sticker',
+  'location',
+  'contacts',
+  'template',
+  'buttons',
+  'list',
+  'cta_url',
+  'address_request',
+  'flow',
+]);
 
-// ─── Type handlers for /test ──────────────────────────────────────────────────
-
-async function handleText(token: string, phoneId: string, dest: string, p: Record<string, unknown>) {
-  return sendText(token, phoneId, dest, String(p.body ?? ''), { preview_url: Boolean(p.preview_url) });
-}
-
-async function handleMedia(type: string, token: string, phoneId: string, dest: string, p: Record<string, unknown>) {
-  const media = mediaFrom(p);
-  const caption = typeof p.caption === 'string' ? p.caption : undefined;
-  switch (type) {
-    case 'image':
-      return sendImage(token, phoneId, dest, media, { caption });
-    case 'audio':
-      return sendAudio(token, phoneId, dest, media);
-    case 'video':
-      return sendVideo(token, phoneId, dest, media, { caption });
-    case 'sticker':
-      return sendSticker(token, phoneId, dest, media);
-    case 'document':
-      return sendDocument(token, phoneId, dest, media, {
-        caption,
-        filename: typeof p.filename === 'string' ? p.filename : undefined,
-      });
-    default:
-      return undefined;
-  }
-}
-
-async function handleTestType(
+// ─── Handle types NOT in the unified service (need messageId, or are utility) ─
+async function handleNonUnifiedType(
   type: string,
   token: string,
   phoneId: string,
@@ -98,29 +62,6 @@ async function handleTestType(
   res: Response,
 ): Promise<unknown> {
   switch (type) {
-    case 'text':
-      return handleText(token, phoneId, dest, p);
-    case 'image':
-    case 'audio':
-    case 'video':
-    case 'sticker':
-    case 'document':
-      return handleMedia(type, token, phoneId, dest, p);
-    case 'location':
-      return sendLocation(token, phoneId, dest, {
-        latitude: Number(p.latitude),
-        longitude: Number(p.longitude),
-        name: typeof p.name === 'string' ? p.name : undefined,
-        address: typeof p.address === 'string' ? p.address : undefined,
-      });
-    case 'contacts':
-      return sendContacts(token, phoneId, dest, p.contacts as WaContact[]);
-    case 'buttons':
-      return sendButtons(token, phoneId, dest, p as unknown as WaButtonsOpts);
-    case 'list':
-      return sendList(token, phoneId, dest, p as unknown as WaListOpts);
-    case 'template':
-      return sendTemplate(token, phoneId, dest, p as unknown as WaTemplateOpts);
     case 'reaction':
       return sendReaction(token, phoneId, dest, String(p.message_id ?? ''), String(p.emoji ?? ''));
     case 'read':
@@ -133,12 +74,6 @@ async function handleTestType(
       }
       return sendTypingIndicator(token, phoneId, msgId);
     }
-    case 'cta_url':
-      return sendCtaUrlButton(token, phoneId, dest, p as unknown as WaCtaUrlOpts);
-    case 'address_request':
-      return sendAddressRequest(token, phoneId, dest, p as unknown as WaAddressRequestOpts);
-    case 'flow':
-      return sendFlow(token, phoneId, dest, p as unknown as WaFlowOpts);
     case 'get_media_url': {
       const mediaId = String(p.media_id ?? '');
       if (!mediaId) {
@@ -278,8 +213,8 @@ export default express
   })
 
   // ── POST /api/sample-api/whatsapp/send ──────────────────────────────────────
-  // Simple text send. Body: { to, message }
-  // Requires authenticated user with tenant_id for credential resolution.
+  // Simple text send via unified comms service.
+  // Body: { to, message, configLabel? }
   .post('/send', async (req: Request, res: Response) => {
     const { to, message, configLabel } = req.body as { to?: string; message?: string; configLabel?: string };
     if (!to || !message) {
@@ -292,11 +227,15 @@ export default express
         res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
         return;
       }
-      const config = await resolveCommsCredentials(tenantId, 'whatsapp', configLabel);
-      const token = config.credentials.token;
-      const phoneId = config.senderIdentity.phone_number_id;
-      await sendText(token, phoneId, to, message);
-      res.json({ ok: true });
+      const result = await send({
+        tenantId,
+        configLabel,
+        channel: 'whatsapp',
+        to,
+        type: 'text',
+        payload: { text: message },
+      });
+      res.json({ ok: result.success, result });
     } catch (err: unknown) {
       res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }
@@ -304,9 +243,8 @@ export default express
 
   // ── POST /api/sample-api/whatsapp/test ──────────────────────────────────────
   // Multi-type test dispatcher.
-  // Body: { type, to, ...type-specific fields }
-  // Requires authenticated user with tenant_id for credential resolution.
-  // See WhatsAppTest.vue for sample payloads per type.
+  // Body: { type, to, configLabel?, ...type-specific fields }
+  // Types in the unified service go through send(). Others use direct library calls.
   .post('/test', async (req: Request, res: Response) => {
     const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
     if (!tenantId) {
@@ -315,19 +253,6 @@ export default express
     }
 
     const { type, to, configLabel, ...p } = req.body as Record<string, unknown>;
-
-    let token: string;
-    let phoneId: string;
-    try {
-      const config = await resolveCommsCredentials(tenantId, 'whatsapp', configLabel as string | undefined);
-      token = config.credentials.token;
-      phoneId = config.senderIdentity.phone_number_id;
-    } catch (err: unknown) {
-      res
-        .status(500)
-        .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve WhatsApp credentials' });
-      return;
-    }
 
     if (!type || typeof type !== 'string') {
       res.status(400).json({ ok: false, error: 'type is required' });
@@ -339,13 +264,75 @@ export default express
       return;
     }
 
+    const dest = String(to ?? '');
+
     try {
-      const dest = to as string;
-      const result = await handleTestType(type, token, phoneId, dest, p, res);
-      if (result === null) return; // response already sent by handler
-      res.json({ ok: true, result });
+      if (UNIFIED_TYPES.has(type)) {
+        // Use unified send() — handles credential resolution internally
+        const result = await send({
+          tenantId,
+          configLabel: configLabel as string | undefined,
+          channel: 'whatsapp',
+          to: dest,
+          type,
+          payload: p,
+        });
+        if (!result.success) {
+          res.status(500).json({ ok: false, error: result.error });
+          return;
+        }
+        res.json({ ok: true, result });
+      } else {
+        // Non-unified types — resolve credentials manually, call library directly
+        const config = await resolveCommsCredentials(tenantId, 'whatsapp', configLabel as string | undefined);
+        const token = config.credentials.token;
+        const phoneId = config.senderIdentity.phone_number_id;
+
+        const result = await handleNonUnifiedType(type, token, phoneId, dest, p, res);
+        if (result === null) return; // response already sent by handler
+        res.json({ ok: true, result });
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An unexpected error occurred';
       res.status(500).json({ ok: false, error: message });
+    }
+  })
+
+  // ── POST /api/sample-api/whatsapp/broadcast ─────────────────────────────────
+  // Send the same message to multiple recipients.
+  // Body: { recipients: string[], type, configLabel?, ...payload }
+  // Example: { recipients: ["+60111", "+60222"], type: "text", text: "Hello everyone!" }
+  .post('/broadcast', async (req: Request, res: Response) => {
+    const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+    if (!tenantId) {
+      res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
+      return;
+    }
+
+    const { recipients, type, configLabel, ...payload } = req.body as Record<string, unknown>;
+
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      res.status(400).json({ ok: false, error: 'recipients (array of phone numbers) is required' });
+      return;
+    }
+
+    if (!type || typeof type !== 'string') {
+      res.status(400).json({ ok: false, error: 'type is required' });
+      return;
+    }
+
+    try {
+      const result = await broadcast({
+        tenantId,
+        configLabel: configLabel as string | undefined,
+        channel: 'whatsapp',
+        recipients: recipients as string[],
+        type,
+        payload,
+        options: { mode: 'sequential', delayMs: 1000 },
+      });
+      res.json({ ok: result.success, result });
+    } catch (err: unknown) {
+      res.status(500).json({ ok: false, error: err instanceof Error ? err.message : 'An unexpected error occurred' });
     }
   });

--- a/apps/sample-api/src/whatsapp/routes.ts
+++ b/apps/sample-api/src/whatsapp/routes.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
+import { resolveCommsConfigByIdentity, resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import { parseWebhook } from '@common/node/comms/whatsapp2/inbound';
 import {
   getMediaUrl,
@@ -37,13 +37,23 @@ import express from 'express';
 // WhatsApp Cloud API webhook handler
 // Docs: https://developers.facebook.com/documentation/business-messaging/whatsapp/messages/send-messages
 //
-// Required env vars (set in .env.local):
-//   WHATSAPP_APP_SECRET      — from Meta App Dashboard → App Settings → Basic → App Secret
-//   WHATSAPP_VERIFY_TOKEN    — your own secret string (used once during webhook registration)
-//   WHATSAPP_TOKEN           — permanent system user access token
-//   WHATSAPP_PHONE_NUMBER_ID — phone number ID from Meta App Dashboard
+// Multi-config architecture:
+//   - Each tenant can have multiple WhatsApp configs (different phone numbers / Meta Apps)
+//   - Inbound webhooks are routed by phone_number_id from the payload
+//   - Signature verification uses per-config app_secret (from credentials)
+//   - Webhook verification (GET) checks verify_token against all stored configs
+//   - Falls back to env vars (WHATSAPP_APP_SECRET, WHATSAPP_VERIFY_TOKEN) for backward compat
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Verify HMAC-SHA256 signature from Meta webhook */
+function verifySignature(appSecret: string, rawBody: Buffer, signatureHeader: string): boolean {
+  const expected = `sha256=${createHmac('sha256', appSecret).update(rawBody).digest('hex')}`;
+  const sigBuf = Buffer.from(signatureHeader);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length) return false;
+  return timingSafeEqual(sigBuf, expBuf);
+}
 
 function mediaFrom(p: Record<string, unknown>): WaMediaInput {
   if (typeof p.id === 'string') return { id: p.id };
@@ -149,77 +159,122 @@ export default express
   // ── GET /api/sample-api/whatsapp/webhook ────────────────────────────────────
   // Meta calls this once when you click "Verify and save" in the App Dashboard.
   // Your server must echo back hub.challenge or the webhook will not be registered.
-  .get('/webhook', (req, res) => {
+  // Supports multi-config: checks verify_token against all stored WhatsApp configs.
+  .get('/webhook', async (req, res) => {
     const mode = req.query['hub.mode'];
-    const token = req.query['hub.verify_token'];
+    const token = req.query['hub.verify_token'] as string | undefined;
     const challenge = req.query['hub.challenge'];
 
-    if (mode === 'subscribe' && token === process.env.WHATSAPP_VERIFY_TOKEN) {
-      // Echo challenge as plain text — sanitize to prevent reflected XSS
-      res
-        .set('Content-Type', 'text/plain')
-        .status(200)
-        .send(String(challenge ?? ''));
-    } else {
-      res.sendStatus(403);
+    if (mode === 'subscribe' && token) {
+      // Try to find a config with this verify_token
+      const config = await resolveCommsConfigByIdentity('whatsapp', 'verify_token', token);
+
+      if (config) {
+        res
+          .set('Content-Type', 'text/plain')
+          .status(200)
+          .send(String(challenge ?? ''));
+        return;
+      }
+
+      // Fallback: check legacy env var for backward compatibility
+      if (token === process.env.WHATSAPP_VERIFY_TOKEN) {
+        res
+          .set('Content-Type', 'text/plain')
+          .status(200)
+          .send(String(challenge ?? ''));
+        return;
+      }
     }
+
+    res.sendStatus(403);
   })
 
   // ── POST /api/sample-api/whatsapp/webhook ───────────────────────────────────
   // Meta sends every inbound message here.
-  // Respond 200 immediately — Meta will retry if you don't.
+  // Multi-config: resolves config by phone_number_id, verifies signature per-config.
   .post('/webhook', async (req, res) => {
-    // ── Signature verification ────────────────────────────────────────────────
-    // Meta signs every POST with HMAC-SHA256 of the raw body using the App Secret.
-    // Skip check if WHATSAPP_APP_SECRET is not configured (dev convenience).
-    const appSecret = process.env.WHATSAPP_APP_SECRET;
-    if (appSecret) {
-      const sig = String(req.headers['x-hub-signature-256'] ?? '');
-      const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
-      if (!rawBody) {
-        res.sendStatus(403);
-        return;
-      }
-      const expected = `sha256=${createHmac('sha256', appSecret).update(rawBody).digest('hex')}`;
-      const sigBuf = Buffer.from(sig);
-      const expBuf = Buffer.from(expected);
-      if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
-        res.sendStatus(403);
-        return;
-      }
-    }
-
-    res.sendStatus(200); // always ack first
+    // Always respond 200 immediately — Meta will retry if you don't (< 5s requirement)
+    res.sendStatus(200);
 
     const body = req.body;
 
     // Safety check — only handle whatsapp_business_account events
     if (body?.object !== 'whatsapp_business_account') return;
 
-    const { WHATSAPP_TOKEN: token = '', WHATSAPP_PHONE_NUMBER_ID: phoneId = '' } = process.env;
-    const { messages } = parseWebhook(body);
+    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    const signatureHeader = String(req.headers['x-hub-signature-256'] ?? '');
 
+    // Parse webhook to extract phone_number_id for config resolution
+    const { phoneNumberId, messages } = parseWebhook(body);
+
+    if (!phoneNumberId) {
+      console.warn('WA webhook: no phone_number_id in payload');
+      return;
+    }
+
+    // Resolve config by phone_number_id
+    const config = await resolveCommsConfigByIdentity('whatsapp', 'phone_number_id', phoneNumberId);
+
+    if (config) {
+      // Verify signature using config's app_secret
+      const appSecret = config.credentials.app_secret;
+      if (appSecret && rawBody) {
+        if (!verifySignature(appSecret, rawBody, signatureHeader)) {
+          console.error('WA webhook: signature verification failed for config', config.label);
+          return;
+        }
+      }
+
+      // Process messages in tenant context
+      if (messages.length === 0) return;
+
+      const token = config.credentials.token;
+      const phoneId = config.senderIdentity.phone_number_id;
+      const msg = messages[0];
+
+      // Only handle inbound text messages for now
+      if (msg.content.type !== 'text') return;
+
+      const userText = msg.content.body.trim().toLowerCase();
+
+      // Simple echo / greeting handler — extend or replace with AI/service layer
+      let reply: string;
+      if (userText === 'hello' || userText === 'hi') {
+        reply = 'Hi! What can I help you with?';
+      } else {
+        reply = `You said: "${msg.content.body}". (This bot is a work in progress.)`;
+      }
+
+      await sendText(token, phoneId, msg.from, reply);
+      return;
+    }
+
+    // Fallback: legacy env-var based handling (backward compatibility)
+    const legacyAppSecret = process.env.WHATSAPP_APP_SECRET;
+    if (legacyAppSecret && rawBody) {
+      if (!verifySignature(legacyAppSecret, rawBody, signatureHeader)) {
+        console.error('WA webhook: legacy signature verification failed');
+        return;
+      }
+    }
+
+    const { WHATSAPP_TOKEN: legacyToken = '', WHATSAPP_PHONE_NUMBER_ID: legacyPhoneId = '' } = process.env;
     if (messages.length === 0) return;
-    if (!token || !phoneId) return; // silently skip if env not configured
+    if (!legacyToken || !legacyPhoneId) return;
 
     const msg = messages[0];
-
-    // Only handle inbound text messages for now
     if (msg.content.type !== 'text') return;
 
     const userText = msg.content.body.trim().toLowerCase();
-
-    // ── Simple echo / greeting handler ─────────────────────────────────────
-    // Extend this block to add more commands or wire in an AI agent later.
     let reply: string;
-
     if (userText === 'hello' || userText === 'hi') {
       reply = 'Hi! What can I help you with?';
     } else {
       reply = `You said: "${msg.content.body}". (This bot is a work in progress.)`;
     }
 
-    await sendText(token, phoneId, msg.from, reply);
+    await sendText(legacyToken, legacyPhoneId, msg.from, reply);
   })
 
   // ── POST /api/sample-api/whatsapp/send ──────────────────────────────────────

--- a/apps/sample-api/src/whatsapp/template-routes.ts
+++ b/apps/sample-api/src/whatsapp/template-routes.ts
@@ -1,3 +1,4 @@
+import { resolveCommsCredentials } from '@common/node/comms/tenant/resolver';
 import type { WaTemplateCreate, WaTemplateUpdate } from '@common/node/comms/whatsapp2/template';
 import { createTemplate, deleteTemplate, listTemplates, updateTemplate } from '@common/node/comms/whatsapp2/template';
 import type { Request, Response } from 'express';
@@ -6,25 +7,42 @@ import express from 'express';
 // WhatsApp Template Management API
 // Docs: https://developers.facebook.com/documentation/business-messaging/whatsapp/business-management-api/message-templates
 //
-// Required env vars:
-//   WHATSAPP_TOKEN                — permanent system user access token (needs whatsapp_business_management scope)
-//   WHATSAPP_BUSINESS_ACCOUNT_ID  — WABA ID from Meta Business Manager
+// Credentials are resolved per-tenant from the database via resolveCommsCredentials().
+// Pass ?configLabel=xxx query param to select which WhatsApp config to use.
 
-function getCredentials(res: Response): { token: string; wabaId: string } | null {
-  const { WHATSAPP_TOKEN: token = '', WHATSAPP_BUSINESS_ACCOUNT_ID: wabaId = '' } = process.env;
-  if (!token || !wabaId) {
-    res.status(500).json({ ok: false, error: 'WHATSAPP_TOKEN or WHATSAPP_BUSINESS_ACCOUNT_ID not set' });
+async function getCredentials(req: Request, res: Response): Promise<{ token: string; wabaId: string } | null> {
+  const tenantId = (req as any).user?.tenant_id ?? (process.env.NODE_ENV === 'development' ? 1 : null);
+  if (!tenantId) {
+    res.status(401).json({ ok: false, error: 'Authenticated user with tenant_id is required' });
     return null;
   }
-  return { token, wabaId };
+  const configLabel = (req.query.configLabel as string) || (req.body?.configLabel as string) || undefined;
+  try {
+    const config = await resolveCommsCredentials(tenantId, 'whatsapp', configLabel);
+    const token = config.credentials.token;
+    const wabaId = config.senderIdentity.business_account_id;
+    if (!token || !wabaId) {
+      res
+        .status(500)
+        .json({ ok: false, error: 'WhatsApp config is missing token or business_account_id in sender identity' });
+      return null;
+    }
+    return { token, wabaId };
+  } catch (err: unknown) {
+    res
+      .status(500)
+      .json({ ok: false, error: err instanceof Error ? err.message : 'Failed to resolve WhatsApp credentials' });
+    return null;
+  }
 }
 
 export default express
   .Router()
 
   // ── GET /api/sample-api/whatsapp/templates ───────────────────────────────
+  // Query: ?limit=N&status=APPROVED|PENDING|...&configLabel=xxx
   .get('/', async (req: Request, res: Response) => {
-    const creds = getCredentials(res);
+    const creds = await getCredentials(req, res);
     if (!creds) return;
 
     const limit = req.query.limit ? Number(req.query.limit) : 20;
@@ -41,8 +59,9 @@ export default express
   })
 
   // ── POST /api/sample-api/whatsapp/templates ──────────────────────────────
+  // Body: { name, language, category, components, configLabel? }
   .post('/', async (req: Request, res: Response) => {
-    const creds = getCredentials(res);
+    const creds = await getCredentials(req, res);
     if (!creds) return;
 
     const payload = req.body as WaTemplateCreate;
@@ -62,8 +81,9 @@ export default express
   })
 
   // ── POST /api/sample-api/whatsapp/templates/:id ──────────────────────────
+  // Body: { components, configLabel? }
   .post('/:id', async (req: Request, res: Response) => {
-    const creds = getCredentials(res);
+    const creds = await getCredentials(req, res);
     if (!creds) return;
 
     const templateId = req.params.id;
@@ -83,9 +103,9 @@ export default express
     }
   })
 
-  // ── DELETE /api/sample-api/whatsapp/templates?name=xxx ──────────────────
+  // ── DELETE /api/sample-api/whatsapp/templates?name=xxx&configLabel=xxx ──
   .delete('/', async (req: Request, res: Response) => {
-    const creds = getCredentials(res);
+    const creds = await getCredentials(req, res);
     if (!creds) return;
 
     const name = req.query.name ? String(req.query.name) : '';

--- a/apps/sample-vue-full/setups/routes.js
+++ b/apps/sample-vue-full/setups/routes.js
@@ -73,6 +73,7 @@ export const SECURE_ROUTES = [
     name: 'Email Templates',
     component: async () => import('../views/SendgridTemplates.vue'),
   },
+  { path: '/comms-config', name: 'Comms Config', component: async () => import('../views/TenantCommsConfig.vue') },
 
   { path: '/demo-view/fill', name: 'Fill No Param', component: async () => import('../views/Demo/Filler.vue') },
   {

--- a/apps/sample-vue-full/setups/routes.js
+++ b/apps/sample-vue-full/setups/routes.js
@@ -63,17 +63,32 @@ export const SECURE_ROUTES = [
 
   { path: '/whatsapp/test', name: 'WhatsApp Test', component: async () => import('../views/WhatsAppTest.vue') },
   {
+    path: '/whatsapp/broadcast',
+    name: 'WA Broadcast',
+    component: async () => import('../views/WhatsAppBroadcast.vue'),
+  },
+  {
     path: '/whatsapp/templates',
     name: 'WA Templates',
     component: async () => import('../views/WhatsAppTemplates.vue'),
   },
   { path: '/sendgrid/test', name: 'Email Test', component: async () => import('../views/SendgridTest.vue') },
   {
+    path: '/sendgrid/broadcast',
+    name: 'Email Broadcast',
+    component: async () => import('../views/SendgridBroadcast.vue'),
+  },
+  {
     path: '/sendgrid/templates',
     name: 'Email Templates',
     component: async () => import('../views/SendgridTemplates.vue'),
   },
   { path: '/telegram/test', name: 'Telegram Test', component: async () => import('../views/TelegramTest.vue') },
+  {
+    path: '/telegram/broadcast',
+    name: 'TG Broadcast',
+    component: async () => import('../views/TelegramBroadcast.vue'),
+  },
   { path: '/comms-config', name: 'Comms Config', component: async () => import('../views/TenantCommsConfig.vue') },
 
   { path: '/demo-view/fill', name: 'Fill No Param', component: async () => import('../views/Demo/Filler.vue') },

--- a/apps/sample-vue-full/setups/routes.js
+++ b/apps/sample-vue-full/setups/routes.js
@@ -73,6 +73,7 @@ export const SECURE_ROUTES = [
     name: 'Email Templates',
     component: async () => import('../views/SendgridTemplates.vue'),
   },
+  { path: '/telegram/test', name: 'Telegram Test', component: async () => import('../views/TelegramTest.vue') },
   { path: '/comms-config', name: 'Comms Config', component: async () => import('../views/TenantCommsConfig.vue') },
 
   { path: '/demo-view/fill', name: 'Fill No Param', component: async () => import('../views/Demo/Filler.vue') },

--- a/apps/sample-vue-full/views/SendgridBroadcast.vue
+++ b/apps/sample-vue-full/views/SendgridBroadcast.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="sg-broadcast-wrap">
+    <a-card title="Email Broadcast" style="max-width: 600px; margin: 40px auto">
+      <a-form layout="vertical" @submit.prevent="sendBroadcast">
+        <a-form-item label="Send from (config)">
+          <a-select
+            v-model:value="configLabel"
+            placeholder="Select an Email config"
+            style="width: 100%"
+            :loading="configsLoading"
+          >
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">
+              {{ c.label }} ({{ c.senderIdentity.sender_email }})
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-form-item label="Recipients (one email per line)">
+          <a-textarea
+            v-model:value="recipientsText"
+            :rows="4"
+            placeholder="alice@example.com&#10;bob@example.com&#10;charlie@example.com"
+          />
+          <div style="color: #888; font-size: 12px; margin-top: 4px">
+            {{ recipientCount }} recipient(s)
+          </div>
+        </a-form-item>
+
+        <a-form-item label="Message type">
+          <a-select v-model:value="type" @change="prefill" style="width: 100%">
+            <a-select-option value="html">HTML Email</a-select-option>
+            <a-select-option value="dynamic">Dynamic Template</a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-form-item label="Payload (JSON)">
+          <a-textarea
+            v-model:value="payloadJson"
+            :rows="6"
+            style="font-family: monospace; font-size: 12px"
+            :status="jsonError ? 'error' : ''"
+          />
+          <div v-if="jsonError" style="color: #ff4d4f; font-size: 12px; margin-top: 4px">{{ jsonError }}</div>
+        </a-form-item>
+
+        <a-form-item>
+          <a-button type="primary" html-type="submit" :loading="loading" block>Send Broadcast</a-button>
+        </a-form-item>
+
+        <a-alert
+          v-if="result"
+          :type="result.ok ? 'success' : 'error'"
+          :message="result.ok ? `Broadcast complete: ${result.result?.sent ?? 0} sent, ${result.result?.failed ?? 0} failed` : 'Error'"
+          :description="JSON.stringify(result.result ?? result.error, null, 2)"
+          show-icon
+          style="white-space: pre-wrap; font-family: monospace; font-size: 12px"
+        />
+      </a-form>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'email');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch Email configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+onMounted(fetchConfigs);
+
+// ─── Form state ───────────────────────────────────────────────────────────────
+
+const recipientsText = ref('');
+const type = ref('html');
+const payloadJson = ref('');
+const loading = ref(false);
+const result = ref(null);
+const jsonError = ref('');
+
+const recipientCount = computed(() => {
+  return recipientsText.value
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean).length;
+});
+
+const TEMPLATES = {
+  html: { subject: 'Broadcast Email', html: '<p>Hello from email broadcast!</p>' },
+  dynamic: { templateId: 'd-xxxxx', dynamicData: { name: 'Recipient' } },
+};
+
+function prefill() {
+  payloadJson.value = JSON.stringify(TEMPLATES[type.value] ?? TEMPLATES.html, null, 2);
+}
+prefill();
+
+// ─── Send ─────────────────────────────────────────────────────────────────────
+
+async function sendBroadcast() {
+  jsonError.value = '';
+  result.value = null;
+
+  let payload;
+  try {
+    payload = JSON.parse(payloadJson.value);
+  } catch (e) {
+    jsonError.value = 'Invalid JSON';
+    return;
+  }
+
+  const recipients = recipientsText.value
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+  if (recipients.length === 0) {
+    jsonError.value = 'At least one recipient is required';
+    return;
+  }
+
+  loading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/sendgrid/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        recipients,
+        type: type.value,
+        configLabel: configLabel.value || undefined,
+        ...payload,
+      }),
+    });
+    result.value = await res.json();
+  } catch (err) {
+    result.value = { ok: false, error: err.message };
+  } finally {
+    loading.value = false;
+  }
+}
+</script>

--- a/apps/sample-vue-full/views/SendgridTemplates.vue
+++ b/apps/sample-vue-full/views/SendgridTemplates.vue
@@ -3,7 +3,12 @@
     <!-- ── Template List ─────────────────────────────────────────────────── -->
     <a-card title="Email Templates (SendGrid Dynamic)" style="max-width: 960px; margin: 40px auto">
       <template #extra>
-        <a-button type="primary" @click="openCreateTemplate">New Template</a-button>
+        <a-space>
+          <a-select v-model:value="configLabel" placeholder="Select config" style="width: 200px" :loading="configsLoading" @change="loadTemplates">
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">{{ c.label }} ({{ c.senderIdentity.sender_email }})</a-select-option>
+          </a-select>
+          <a-button type="primary" @click="openCreateTemplate">New Template</a-button>
+        </a-space>
       </template>
 
       <a-alert
@@ -241,6 +246,34 @@ import { onMounted, ref } from 'vue';
 const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
 const BASE = `${API_URL}/api/sample-api/sendgrid/templates`;
 
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'email');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch Email configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+function configQs() {
+  return configLabel.value ? `?configLabel=${encodeURIComponent(configLabel.value)}` : '';
+}
+
 // ── Template table ───────────────────────────────────────────────────────────
 const templateColumns = [
   { title: 'Name', dataIndex: 'name', key: 'name' },
@@ -257,10 +290,11 @@ const listLoading = ref(false);
 const listError = ref('');
 
 const loadTemplates = async () => {
+  if (!configLabel.value) return;
   listLoading.value = true;
   listError.value = '';
   try {
-    const res = await fetch(BASE);
+    const res = await fetch(`${BASE}${configQs()}`, { credentials: 'include' });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error ?? 'Failed to load templates');
     templates.value = json.templates ?? [];
@@ -271,7 +305,10 @@ const loadTemplates = async () => {
   }
 };
 
-onMounted(loadTemplates);
+onMounted(async () => {
+  await fetchConfigs();
+  if (configLabel.value) loadTemplates();
+});
 
 // ── Create Template ──────────────────────────────────────────────────────────
 const createOpen = ref(false);
@@ -293,10 +330,11 @@ const saveCreateTemplate = async () => {
   createSaving.value = true;
   createError.value = '';
   try {
-    const res = await fetch(BASE, {
+    const res = await fetch(`${BASE}${configQs()}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: createName.value.trim() }),
+      credentials: 'include',
+      body: JSON.stringify({ name: createName.value.trim(), configLabel: configLabel.value }),
     });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
@@ -331,10 +369,11 @@ const saveRename = async () => {
   renameSaving.value = true;
   renameError.value = '';
   try {
-    const res = await fetch(`${BASE}/${renameId.value}`, {
+    const res = await fetch(`${BASE}/${renameId.value}${configQs()}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: renameName.value.trim() }),
+      credentials: 'include',
+      body: JSON.stringify({ name: renameName.value.trim(), configLabel: configLabel.value }),
     });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
@@ -365,10 +404,13 @@ const saveDuplicate = async () => {
   dupSaving.value = true;
   dupError.value = '';
   try {
-    const body = dupName.value.trim() ? { name: dupName.value.trim() } : {};
-    const res = await fetch(`${BASE}/${dupId.value}/duplicate`, {
+    const body = dupName.value.trim()
+      ? { name: dupName.value.trim(), configLabel: configLabel.value }
+      : { configLabel: configLabel.value };
+    const res = await fetch(`${BASE}/${dupId.value}/duplicate${configQs()}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(body),
     });
     const json = await res.json();
@@ -385,7 +427,7 @@ const saveDuplicate = async () => {
 // ── Delete Template ──────────────────────────────────────────────────────────
 const deleteOne = async id => {
   try {
-    const res = await fetch(`${BASE}/${id}`, { method: 'DELETE' });
+    const res = await fetch(`${BASE}/${id}${configQs()}`, { method: 'DELETE', credentials: 'include' });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
     await loadTemplates();
@@ -424,12 +466,11 @@ const reloadVersions = async () => {
   versionLoading.value = true;
   versionListError.value = '';
   try {
-    const res = await fetch(`${BASE}/${selectedTemplate.value.id}`);
+    const res = await fetch(`${BASE}/${selectedTemplate.value.id}${configQs()}`, { credentials: 'include' });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error ?? 'Failed to load versions');
     const versions = json.versions ?? [];
     selectedVersions.value = versions;
-    // Update the active version display in the main list (replace array via map for reliable reactivity)
     templates.value = templates.value.map(t => (t.id === selectedTemplate.value.id ? { ...t, versions } : t));
   } catch (err) {
     versionListError.value = err?.message ?? String(err);
@@ -441,8 +482,9 @@ const reloadVersions = async () => {
 const activateVersion = async version => {
   versionActionMsg.value = null;
   try {
-    const res = await fetch(`${BASE}/${selectedTemplate.value.id}/versions/${version.id}/activate`, {
+    const res = await fetch(`${BASE}/${selectedTemplate.value.id}/versions/${version.id}/activate${configQs()}`, {
       method: 'POST',
+      credentials: 'include',
     });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
@@ -456,8 +498,9 @@ const activateVersion = async version => {
 const deleteVersion = async version => {
   versionActionMsg.value = null;
   try {
-    const res = await fetch(`${BASE}/${selectedTemplate.value.id}/versions/${version.id}`, {
+    const res = await fetch(`${BASE}/${selectedTemplate.value.id}/versions/${version.id}${configQs()}`, {
       method: 'DELETE',
+      credentials: 'include',
     });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
@@ -518,16 +561,18 @@ const saveVersion = async () => {
 
     let res;
     if (editVersionId.value) {
-      res = await fetch(`${BASE}/${templateId}/versions/${editVersionId.value}`, {
+      res = await fetch(`${BASE}/${templateId}/versions/${editVersionId.value}${configQs()}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        credentials: 'include',
+        body: JSON.stringify({ ...payload, configLabel: configLabel.value }),
       });
     } else {
-      res = await fetch(`${BASE}/${templateId}/versions`, {
+      res = await fetch(`${BASE}/${templateId}/versions${configQs()}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        credentials: 'include',
+        body: JSON.stringify({ ...payload, configLabel: configLabel.value }),
       });
     }
 

--- a/apps/sample-vue-full/views/SendgridTest.vue
+++ b/apps/sample-vue-full/views/SendgridTest.vue
@@ -2,6 +2,12 @@
   <div class="email-test-wrap">
     <a-card title="SendGrid Email Test" style="max-width: 640px; margin: 40px auto">
       <a-form layout="vertical" @submit.prevent="send">
+        <a-form-item label="Send from (config)">
+          <a-select v-model:value="configLabel" placeholder="Select an Email config" style="width: 100%" :loading="configsLoading">
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">{{ c.label }} ({{ c.senderIdentity.sender_email }})</a-select-option>
+          </a-select>
+        </a-form-item>
+
         <a-row :gutter="12">
           <a-col :span="10">
             <a-form-item label="Message type">
@@ -49,9 +55,35 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 
 const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'email');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch Email configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+onMounted(fetchConfigs);
 
 const TYPES = [
   { value: 'html', label: 'HTML Email' },
@@ -181,7 +213,7 @@ async function send() {
     return;
   }
 
-  const payload = { type: type.value, to: to.value, ...parsed };
+  const payload = { type: type.value, to: to.value, configLabel: configLabel.value, ...parsed };
   loading.value = true;
   result.value = null;
   try {

--- a/apps/sample-vue-full/views/TelegramBroadcast.vue
+++ b/apps/sample-vue-full/views/TelegramBroadcast.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="tg-broadcast-wrap">
+    <a-card title="Telegram Broadcast" style="max-width: 600px; margin: 40px auto">
+      <a-form layout="vertical" @submit.prevent="sendBroadcast">
+        <a-form-item label="Send from (config)">
+          <a-select
+            v-model:value="configLabel"
+            placeholder="Select a Telegram config"
+            style="width: 100%"
+            :loading="configsLoading"
+          >
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">
+              {{ c.label }}{{ c.senderIdentity.bot_name ? ` (${c.senderIdentity.bot_name})` : '' }}
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-form-item label="Recipients (one chat ID per line)">
+          <a-textarea
+            v-model:value="recipientsText"
+            :rows="4"
+            placeholder="123456789&#10;987654321&#10;-1001234567890"
+          />
+          <div style="color: #888; font-size: 12px; margin-top: 4px">
+            {{ recipientCount }} recipient(s)
+          </div>
+        </a-form-item>
+
+        <a-form-item label="Message type">
+          <a-select v-model:value="type" @change="prefill" style="width: 100%">
+            <a-select-option value="text">Text</a-select-option>
+            <a-select-option value="photo">Photo</a-select-option>
+            <a-select-option value="document">Document</a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-form-item label="Payload (JSON)">
+          <a-textarea
+            v-model:value="payloadJson"
+            :rows="6"
+            style="font-family: monospace; font-size: 12px"
+            :status="jsonError ? 'error' : ''"
+          />
+          <div v-if="jsonError" style="color: #ff4d4f; font-size: 12px; margin-top: 4px">{{ jsonError }}</div>
+        </a-form-item>
+
+        <a-form-item>
+          <a-button type="primary" html-type="submit" :loading="loading" block>Send Broadcast</a-button>
+        </a-form-item>
+
+        <a-alert
+          v-if="result"
+          :type="result.ok ? 'success' : 'error'"
+          :message="result.ok ? `Broadcast complete: ${result.result?.sent ?? 0} sent, ${result.result?.failed ?? 0} failed` : 'Error'"
+          :description="JSON.stringify(result.result ?? result.error, null, 2)"
+          show-icon
+          style="white-space: pre-wrap; font-family: monospace; font-size: 12px"
+        />
+      </a-form>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'telegram');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch Telegram configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+onMounted(fetchConfigs);
+
+// ─── Form state ───────────────────────────────────────────────────────────────
+
+const recipientsText = ref('');
+const type = ref('text');
+const payloadJson = ref('');
+const loading = ref(false);
+const result = ref(null);
+const jsonError = ref('');
+
+const recipientCount = computed(() => {
+  return recipientsText.value
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean).length;
+});
+
+const TEMPLATES = {
+  text: { text: 'Hello from Telegram broadcast!' },
+  photo: {
+    photo:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png',
+    caption: 'Broadcast photo',
+  },
+  document: { document: 'https://www.w3.org/WAI/WCAG21/Techniques/pdf/sample.pdf', caption: 'Broadcast document' },
+};
+
+function prefill() {
+  payloadJson.value = JSON.stringify(TEMPLATES[type.value] ?? TEMPLATES.text, null, 2);
+}
+prefill();
+
+// ─── Send ─────────────────────────────────────────────────────────────────────
+
+async function sendBroadcast() {
+  jsonError.value = '';
+  result.value = null;
+
+  let payload;
+  try {
+    payload = JSON.parse(payloadJson.value);
+  } catch (e) {
+    jsonError.value = 'Invalid JSON';
+    return;
+  }
+
+  const recipients = recipientsText.value
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+  if (recipients.length === 0) {
+    jsonError.value = 'At least one recipient is required';
+    return;
+  }
+
+  loading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/telegram/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        recipients,
+        type: type.value,
+        configLabel: configLabel.value || undefined,
+        ...payload,
+      }),
+    });
+    result.value = await res.json();
+  } catch (err) {
+    result.value = { ok: false, error: err.message };
+  } finally {
+    loading.value = false;
+  }
+}
+</script>

--- a/apps/sample-vue-full/views/TelegramTest.vue
+++ b/apps/sample-vue-full/views/TelegramTest.vue
@@ -1,0 +1,330 @@
+<template>
+  <div class="tg-test-wrap">
+    <a-card title="Telegram Bot Test Sender" style="max-width: 600px; margin: 40px auto">
+      <a-form layout="vertical" @submit.prevent="send">
+        <a-form-item label="Send from (config)">
+          <a-select
+            v-model:value="configLabel"
+            placeholder="Select a Telegram config"
+            style="width: 100%"
+            :loading="configsLoading"
+          >
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">
+              {{ c.label }}{{ c.senderIdentity.bot_name ? ` (${c.senderIdentity.bot_name})` : '' }}
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-row :gutter="12">
+          <a-col :span="12">
+            <a-form-item label="Message type">
+              <a-select v-model:value="type" @change="prefill" style="width: 100%">
+                <a-select-option v-for="t in TYPES" :key="t.value" :value="t.value">{{ t.label }}</a-select-option>
+              </a-select>
+            </a-form-item>
+          </a-col>
+          <a-col :span="12">
+            <a-form-item label="To (chat ID or @username)">
+              <a-input v-model:value="to" placeholder="123456789 or @username or -100123456789" />
+            </a-form-item>
+          </a-col>
+        </a-row>
+
+        <a-form-item label="Body (JSON)">
+          <a-textarea
+            v-model:value="bodyJson"
+            :rows="10"
+            style="font-family: monospace; font-size: 12px"
+            :status="jsonError ? 'error' : ''"
+          />
+          <div v-if="jsonError" style="color: #ff4d4f; font-size: 12px; margin-top: 4px">{{ jsonError }}</div>
+        </a-form-item>
+
+        <a-form-item>
+          <a-button type="primary" html-type="submit" :loading="loading" block>Send</a-button>
+        </a-form-item>
+
+        <a-alert
+          v-if="result"
+          :type="result.ok ? 'success' : 'error'"
+          :message="result.ok ? 'Sent successfully' : 'Error'"
+          :description="result.ok ? JSON.stringify(result.result, null, 2) : result.error"
+          show-icon
+          style="white-space: pre-wrap; font-family: monospace; font-size: 12px"
+        />
+      </a-form>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref, watch } from 'vue';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'telegram');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch Telegram configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+onMounted(fetchConfigs);
+
+const TYPES = [
+  { value: 'message', label: 'Text Message' },
+  { value: 'photo', label: 'Photo' },
+  { value: 'video', label: 'Video' },
+  { value: 'audio', label: 'Audio' },
+  { value: 'document', label: 'Document / File' },
+  { value: 'voice', label: 'Voice Message (OGG/OPUS)' },
+  { value: 'video_note', label: 'Video Note (Round Video)' },
+  { value: 'sticker', label: 'Sticker' },
+  { value: 'animation', label: 'Animation (GIF)' },
+  { value: 'media_group', label: 'Media Group (Album)' },
+  { value: 'location', label: 'Location' },
+  { value: 'venue', label: 'Venue' },
+  { value: 'contact', label: 'Contact' },
+  { value: 'poll', label: 'Poll' },
+  { value: 'dice', label: 'Dice / Game' },
+  { value: 'chat_action', label: 'Chat Action (Typing Indicator)' },
+  { value: 'forward', label: 'Forward Message' },
+  { value: 'copy', label: 'Copy Message' },
+  { value: 'edit_text', label: 'Edit Message Text' },
+  { value: 'edit_caption', label: 'Edit Message Caption' },
+  { value: 'edit_markup', label: 'Edit Reply Markup' },
+  { value: 'delete', label: 'Delete Message' },
+  { value: 'pin', label: 'Pin Message' },
+  { value: 'unpin', label: 'Unpin Message' },
+];
+
+const TEMPLATES = {
+  message: {
+    text: 'Hello from the Telegram test page!',
+    '_docs (remove this)':
+      'Optional: parse_mode ("HTML"|"Markdown"|"MarkdownV2"), disable_web_page_preview, reply_markup',
+    parse_mode: 'HTML',
+  },
+  photo: {
+    photo:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png',
+    caption: 'Test photo',
+    '_docs (remove this)':
+      'photo: HTTPS URL, local path, or "file_id:<id>". Optional: has_spoiler, caption, parse_mode',
+  },
+  video: {
+    video: 'https://www.w3schools.com/html/mov_bbb.mp4',
+    caption: 'Test video',
+    '_docs (remove this)':
+      'video: HTTPS URL, local path, or "file_id:<id>". Optional: duration, width, height, supports_streaming, has_spoiler, thumbnail',
+  },
+  audio: {
+    audio: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+    caption: 'Test audio',
+    performer: 'Test Artist',
+    title: 'Test Song',
+    '_docs (remove this)':
+      'audio: HTTPS URL, local path, or "file_id:<id>". Optional: duration, performer, title, thumbnail',
+  },
+  document: {
+    document: 'https://www.w3.org/WAI/WCAG21/Techniques/pdf/sample.pdf',
+    caption: 'Sample PDF',
+    '_docs (remove this)':
+      'document: HTTPS URL, local path, or "file_id:<id>". Optional: thumbnail, disable_content_type_detection',
+  },
+  voice: {
+    voice: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+    '_docs (remove this)':
+      'voice: OGG/OPUS encoded audio. HTTPS URL, local path, or "file_id:<id>". Optional: duration',
+  },
+  video_note: {
+    video_note: 'file_id:<replace_with_actual_file_id>',
+    '_docs (remove this)':
+      'video_note: must be 1:1 aspect ratio, max 639px diameter. HTTPS URL, local path, or "file_id:<id>". Optional: duration, length',
+  },
+  sticker: {
+    sticker: 'file_id:<replace_with_actual_sticker_file_id>',
+    '_docs (remove this)':
+      'sticker: WEBP, TGS (animated), or WEBM (video) sticker. "file_id:<id>", HTTPS URL, or local path.',
+  },
+  animation: {
+    animation: 'https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif',
+    caption: 'Test animation',
+    '_docs (remove this)':
+      'animation: GIF or H.264/MPEG-4 AVC video. HTTPS URL, local path, or "file_id:<id>". Optional: has_spoiler, duration, width, height',
+  },
+  media_group: {
+    media: [
+      {
+        type: 'photo',
+        file: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png',
+        caption: 'First image',
+      },
+      {
+        type: 'photo',
+        file: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png',
+      },
+    ],
+    '_docs (remove this)':
+      '2–10 items. Each item: { type: "photo"|"video"|"audio"|"document", file, caption?, parse_mode?, has_spoiler? }',
+  },
+  location: {
+    latitude: 3.139,
+    longitude: 101.6869,
+    '_docs (remove this)':
+      'Optional: horizontal_accuracy (0–1500m), live_period (60–86400s for live location), heading (1–360), proximity_alert_radius',
+  },
+  venue: {
+    venue: {
+      latitude: 3.139,
+      longitude: 101.6869,
+      title: 'Kuala Lumpur City Centre',
+      address: 'Kuala Lumpur, Malaysia',
+      foursquare_id: '',
+    },
+    '_docs (remove this)':
+      'venue: { latitude, longitude, title (required), address (required), foursquare_id?, foursquare_type?, google_place_id?, google_place_type? }',
+  },
+  contact: {
+    contact: {
+      phone_number: '+60123456789',
+      first_name: 'John',
+      last_name: 'Doe',
+      vcard: '',
+    },
+    '_docs (remove this)': 'contact: { phone_number (required), first_name (required), last_name?, vcard? }',
+  },
+  poll: {
+    question: 'What is your favourite programming language?',
+    options: ['TypeScript', 'Python', 'Go', 'Rust'],
+    '_docs (remove this)':
+      'options: 2–10 strings. Optional: type ("regular"|"quiz"), is_anonymous, allows_multiple_answers, correct_option_id (quiz only), explanation (quiz only), open_period (5–600s), close_date (unix timestamp)',
+  },
+  dice: {
+    emoji: '🎲',
+    '_docs (remove this)':
+      'emoji: "🎲" (dice) | "🎯" (darts) | "🏀" (basketball) | "⚽" (football) | "🎳" (bowling) | "🎰" (slot machine). Default: 🎲',
+  },
+  chat_action: {
+    action: 'typing',
+    '_docs (remove this)':
+      'action: "typing" | "upload_photo" | "record_video" | "upload_video" | "record_voice" | "upload_voice" | "upload_document" | "choose_sticker" | "find_location" | "record_video_note" | "upload_video_note"',
+  },
+  forward: {
+    from_chat_id: '<source_chat_id>',
+    message_id: 12345,
+    '_docs (remove this)': 'Forwards a message from from_chat_id. to = destination chat ID.',
+  },
+  copy: {
+    from_chat_id: '<source_chat_id>',
+    message_id: 12345,
+    caption: 'Optional new caption',
+    '_docs (remove this)': 'Copies a message without the forward header. to = destination chat ID.',
+  },
+  edit_text: {
+    message_id: 12345,
+    text: 'Updated message text',
+    '_docs (remove this)':
+      'to = the chat where the message lives. message_id = ID of the message to edit. Optional: parse_mode, disable_web_page_preview, reply_markup',
+  },
+  edit_caption: {
+    message_id: 12345,
+    caption: 'Updated caption text',
+    '_docs (remove this)':
+      'to = the chat where the message lives. message_id = ID of the message to edit. Optional: parse_mode, reply_markup',
+  },
+  edit_markup: {
+    message_id: 12345,
+    reply_markup: '{"inline_keyboard":[[{"text":"Button","callback_data":"btn1"}]]}',
+    '_docs (remove this)': 'reply_markup must be a JSON string of an InlineKeyboardMarkup object.',
+  },
+  delete: {
+    message_id: 12345,
+    '_docs (remove this)': 'to = the chat where the message lives. message_id = ID of the message to delete.',
+  },
+  pin: {
+    message_id: 12345,
+    disable_notification: false,
+    '_docs (remove this)':
+      'to = the chat. message_id = ID of the message to pin. disable_notification: true to pin silently.',
+  },
+  unpin: {
+    message_id: 12345,
+    '_docs (remove this)': 'to = the chat. message_id = ID of the message to unpin.',
+  },
+};
+
+const type = ref('message');
+const to = ref('');
+const bodyJson = ref(JSON.stringify(TEMPLATES.message, null, 2));
+const jsonError = ref('');
+const loading = ref(false);
+const result = ref(null);
+
+function prefill() {
+  bodyJson.value = JSON.stringify(TEMPLATES[type.value] ?? {}, null, 2);
+  jsonError.value = '';
+  result.value = null;
+}
+
+watch(bodyJson, () => {
+  try {
+    JSON.parse(bodyJson.value);
+    jsonError.value = '';
+  } catch {
+    jsonError.value = 'Invalid JSON';
+  }
+});
+
+async function send() {
+  jsonError.value = '';
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyJson.value);
+  } catch {
+    jsonError.value = 'Invalid JSON — fix before sending';
+    return;
+  }
+
+  const payload = { type: type.value, to: to.value, configLabel: configLabel.value, ...parsed };
+  loading.value = true;
+  result.value = null;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/telegram/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    result.value = await res.json();
+  } catch (err) {
+    result.value = { ok: false, error: err.message };
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.tg-test-wrap {
+  min-height: 100vh;
+  background: #f5f5f5;
+  padding: 20px;
+}
+</style>

--- a/apps/sample-vue-full/views/TenantCommsConfig.vue
+++ b/apps/sample-vue-full/views/TenantCommsConfig.vue
@@ -52,6 +52,11 @@
       width="600px"
     >
       <a-form layout="vertical" style="margin-top: 16px">
+        <a-form-item label="Label" required>
+          <a-input v-model:value="form.label" placeholder="e.g. support-wa, marketing-email, billing-bot" :disabled="!!editingId" />
+          <div style="color: #888; font-size: 11px; margin-top: 2px">Slug format: lowercase, numbers, hyphens only. No spaces.</div>
+        </a-form-item>
+
         <a-row :gutter="12">
           <a-col :span="12">
             <a-form-item label="Channel" :required="!editingId">
@@ -183,6 +188,7 @@ const submitting = ref(false);
 const editingId = ref(null);
 
 const defaultForm = () => ({
+  label: '',
   channel: 'email',
   provider: 'sendgrid',
   credentials: {},
@@ -193,6 +199,7 @@ const form = ref(defaultForm());
 // ─── Table columns ────────────────────────────────────────────────────────────
 
 const columns = [
+  { title: 'Label', dataIndex: 'label', key: 'label', width: 150 },
   { title: 'Channel', dataIndex: 'channel', key: 'channel', width: 100 },
   { title: 'Provider', dataIndex: 'provider', key: 'provider', width: 100 },
   { title: 'Sender Identity', key: 'senderIdentity', width: 200 },
@@ -236,6 +243,7 @@ async function createConfig() {
   error.value = '';
   try {
     const body = {
+      label: form.value.label,
       channel: form.value.channel,
       provider: form.value.provider,
       credentials: form.value.credentials,
@@ -344,6 +352,7 @@ function showAddModal() {
 function showEditModal(record) {
   editingId.value = record.id;
   form.value = {
+    label: record.label,
     channel: record.channel,
     provider: record.provider,
     credentials: {}, // empty — user must re-enter to update (security)

--- a/apps/sample-vue-full/views/TenantCommsConfig.vue
+++ b/apps/sample-vue-full/views/TenantCommsConfig.vue
@@ -38,6 +38,12 @@
                 {{ getWhatsAppWebhookUrl() }}
               </div>
             </template>
+            <template v-else-if="record.channel === 'email'">
+              <div style="font-size: 11px; word-break: break-all; color: #555">
+                <div>Inbound: {{ getSendGridInboundUrl() }}</div>
+                <div style="margin-top: 2px">Events: {{ getSendGridEventsUrl(record.label) }}</div>
+              </div>
+            </template>
             <template v-else>
               <span style="color: #999; font-size: 11px">—</span>
             </template>
@@ -104,6 +110,10 @@
         <template v-if="form.channel === 'email'">
           <a-form-item label="SendGrid API Key" required>
             <a-input-password v-model:value="form.credentials.api_key" placeholder="SG.xxxxx" />
+          </a-form-item>
+          <a-form-item label="Event Webhook Public Key">
+            <a-input-password v-model:value="form.credentials.event_webhook_public_key" placeholder="MFkwEwYHKoZIzj0C... (ECDSA P-256 public key)" />
+            <div style="color: #888; font-size: 11px; margin-top: 2px">From SendGrid Dashboard > Settings > Mail Settings > Event Webhook > Verification Key. Used for ECDSA signature verification on event webhooks.</div>
           </a-form-item>
         </template>
 
@@ -415,6 +425,16 @@ function getTelegramWebhookUrl(label) {
 /** Build the WhatsApp webhook URL for display */
 function getWhatsAppWebhookUrl() {
   return `${API_URL}/api/sample-api/whatsapp/webhook`;
+}
+
+/** Build the SendGrid Inbound Parse webhook URL for display */
+function getSendGridInboundUrl() {
+  return `${API_URL}/api/sample-api/sendgrid/inbound`;
+}
+
+/** Build the SendGrid Event webhook URL for display (per-config) */
+function getSendGridEventsUrl(label) {
+  return `${API_URL}/api/sample-api/sendgrid/events/${label}`;
 }
 
 /** Manually (re-)register Telegram webhook for a config */

--- a/apps/sample-vue-full/views/TenantCommsConfig.vue
+++ b/apps/sample-vue-full/views/TenantCommsConfig.vue
@@ -27,12 +27,35 @@
               {{ key }}: {{ val }}
             </span>
           </template>
+          <template v-if="column.key === 'webhook'">
+            <template v-if="record.channel === 'telegram'">
+              <div style="font-size: 11px; word-break: break-all; color: #555">
+                {{ getTelegramWebhookUrl(record.label) }}
+              </div>
+            </template>
+            <template v-else-if="record.channel === 'whatsapp'">
+              <div style="font-size: 11px; word-break: break-all; color: #555">
+                {{ getWhatsAppWebhookUrl() }}
+              </div>
+            </template>
+            <template v-else>
+              <span style="color: #999; font-size: 11px">—</span>
+            </template>
+          </template>
           <template v-if="column.key === 'isActive'">
             <a-switch :checked="record.isActive" @change="toggleActive(record)" size="small" />
           </template>
           <template v-if="column.key === 'actions'">
             <a-space>
               <a-button size="small" @click="showEditModal(record)">Edit</a-button>
+              <a-button
+                v-if="record.channel === 'telegram'"
+                size="small"
+                type="primary"
+                ghost
+                :loading="registeringWebhook === record.id"
+                @click="registerWebhook(record)"
+              >Register Webhook</a-button>
               <a-popconfirm title="Delete this config?" @confirm="deleteConfig(record.id)">
                 <a-button size="small" danger>Delete</a-button>
               </a-popconfirm>
@@ -88,6 +111,9 @@
           <a-form-item label="Access Token" required>
             <a-input-password v-model:value="form.credentials.token" placeholder="EAAxxxxx" />
           </a-form-item>
+          <a-form-item label="App Secret" required>
+            <a-input-password v-model:value="form.credentials.app_secret" placeholder="Meta App Secret (for webhook signature verification)" />
+          </a-form-item>
         </template>
 
         <template v-else-if="form.channel === 'telegram'">
@@ -122,6 +148,10 @@
           </a-form-item>
           <a-form-item label="Business Account ID (WABA ID)" required>
             <a-input v-model:value="form.senderIdentity.business_account_id" placeholder="1528784982254938" />
+          </a-form-item>
+          <a-form-item label="Verify Token">
+            <a-input v-model:value="form.senderIdentity.verify_token" placeholder="Your custom verify token (set same value in Meta Dashboard)" />
+            <div style="color: #888; font-size: 11px; margin-top: 2px">Used during Meta webhook subscription verification (GET handshake). Must match what you enter in Meta App Dashboard.</div>
           </a-form-item>
         </template>
 
@@ -186,6 +216,7 @@ const error = ref('');
 const modalVisible = ref(false);
 const submitting = ref(false);
 const editingId = ref(null);
+const registeringWebhook = ref(null);
 
 const defaultForm = () => ({
   label: '',
@@ -199,23 +230,24 @@ const form = ref(defaultForm());
 // ─── Table columns ────────────────────────────────────────────────────────────
 
 const columns = [
-  { title: 'Label', dataIndex: 'label', key: 'label', width: 150 },
-  { title: 'Channel', dataIndex: 'channel', key: 'channel', width: 100 },
-  { title: 'Provider', dataIndex: 'provider', key: 'provider', width: 100 },
-  { title: 'Sender Identity', key: 'senderIdentity', width: 200 },
+  { title: 'Label', dataIndex: 'label', key: 'label', width: 130 },
+  { title: 'Channel', dataIndex: 'channel', key: 'channel', width: 90 },
+  { title: 'Provider', dataIndex: 'provider', key: 'provider', width: 90 },
+  { title: 'Sender Identity', key: 'senderIdentity', width: 180 },
+  { title: 'Webhook URL', key: 'webhook', width: 200 },
   {
     title: 'Credentials',
     dataIndex: 'credentials',
     key: 'credentials',
-    width: 200,
+    width: 180,
     customRender: ({ record }) => {
       return Object.entries(record.credentials || {})
         .map(([k, v]) => `${k}: ${v}`)
         .join(', ');
     },
   },
-  { title: 'Active', key: 'isActive', width: 80 },
-  { title: 'Actions', key: 'actions', width: 150 },
+  { title: 'Active', key: 'isActive', width: 70 },
+  { title: 'Actions', key: 'actions', width: 220 },
 ];
 
 // ─── API calls ────────────────────────────────────────────────────────────────
@@ -372,6 +404,41 @@ function handleSubmit() {
 // ─── Lifecycle ────────────────────────────────────────────────────────────────
 
 onMounted(fetchConfigs);
+
+// ─── Webhook helpers ──────────────────────────────────────────────────────────
+
+/** Build the Telegram webhook URL for display */
+function getTelegramWebhookUrl(label) {
+  return `${API_URL}/api/sample-api/telegram/webhook/${label}`;
+}
+
+/** Build the WhatsApp webhook URL for display */
+function getWhatsAppWebhookUrl() {
+  return `${API_URL}/api/sample-api/whatsapp/webhook`;
+}
+
+/** Manually (re-)register Telegram webhook for a config */
+async function registerWebhook(record) {
+  registeringWebhook.value = record.id;
+  error.value = '';
+  try {
+    const res = await fetch(`${BASE}/${record.id}/register-webhook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    });
+    const data = await res.json();
+    if (data.ok) {
+      alert(`Webhook registered successfully!\n\nURL: ${data.data.webhookUrl}`);
+    } else {
+      error.value = data.error || 'Failed to register webhook';
+    }
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    registeringWebhook.value = null;
+  }
+}
 </script>
 
 <style scoped>

--- a/apps/sample-vue-full/views/TenantCommsConfig.vue
+++ b/apps/sample-vue-full/views/TenantCommsConfig.vue
@@ -1,0 +1,372 @@
+<template>
+  <div class="comms-config-wrap">
+    <a-card title="Communications Config" style="max-width: 900px; margin: 40px auto">
+      <template #extra>
+        <a-button type="primary" @click="showAddModal">+ Add Channel</a-button>
+      </template>
+
+      <a-alert
+        v-if="error"
+        type="error"
+        :message="error"
+        closable
+        @close="error = ''"
+        style="margin-bottom: 16px"
+      />
+
+      <a-table
+        :columns="columns"
+        :data-source="configs"
+        :loading="loading"
+        row-key="id"
+        :pagination="false"
+      >
+        <template #bodyCell="{ column, record }">
+          <template v-if="column.key === 'senderIdentity'">
+            <span v-for="(val, key) in record.senderIdentity" :key="key" style="display: block; font-size: 12px">
+              {{ key }}: {{ val }}
+            </span>
+          </template>
+          <template v-if="column.key === 'isActive'">
+            <a-switch :checked="record.isActive" @change="toggleActive(record)" size="small" />
+          </template>
+          <template v-if="column.key === 'actions'">
+            <a-space>
+              <a-button size="small" @click="showEditModal(record)">Edit</a-button>
+              <a-popconfirm title="Delete this config?" @confirm="deleteConfig(record.id)">
+                <a-button size="small" danger>Delete</a-button>
+              </a-popconfirm>
+            </a-space>
+          </template>
+        </template>
+      </a-table>
+    </a-card>
+
+    <!-- Add/Edit Modal -->
+    <a-modal
+      v-model:open="modalVisible"
+      :title="editingId ? 'Edit Channel Config' : 'Add Channel Config'"
+      @ok="handleSubmit"
+      :confirm-loading="submitting"
+      :ok-text="editingId ? 'Update' : 'Create'"
+      width="600px"
+    >
+      <a-form layout="vertical" style="margin-top: 16px">
+        <a-row :gutter="12">
+          <a-col :span="12">
+            <a-form-item label="Channel" :required="!editingId">
+              <a-select v-model:value="form.channel" :disabled="!!editingId" style="width: 100%" @change="onChannelChange">
+                <a-select-option value="email">Email</a-select-option>
+                <a-select-option value="whatsapp">WhatsApp</a-select-option>
+                <a-select-option value="telegram">Telegram</a-select-option>
+                <a-select-option value="sms">SMS</a-select-option>
+              </a-select>
+            </a-form-item>
+          </a-col>
+          <a-col :span="12">
+            <a-form-item label="Provider">
+              <a-input :value="providerLabel" disabled />
+            </a-form-item>
+          </a-col>
+        </a-row>
+
+        <!-- Dynamic credential fields based on channel -->
+        <a-divider orientation="left" style="font-size: 13px">Credentials (secret)</a-divider>
+
+        <template v-if="form.channel === 'email'">
+          <a-form-item label="SendGrid API Key" required>
+            <a-input-password v-model:value="form.credentials.api_key" placeholder="SG.xxxxx" />
+          </a-form-item>
+        </template>
+
+        <template v-else-if="form.channel === 'whatsapp'">
+          <a-form-item label="Access Token" required>
+            <a-input-password v-model:value="form.credentials.token" placeholder="EAAxxxxx" />
+          </a-form-item>
+        </template>
+
+        <template v-else-if="form.channel === 'telegram'">
+          <a-form-item label="Bot Token" required>
+            <a-input-password v-model:value="form.credentials.bot_token" placeholder="123456:ABC-DEF" />
+          </a-form-item>
+        </template>
+
+        <template v-else-if="form.channel === 'sms'">
+          <a-form-item label="API Key" required>
+            <a-input-password v-model:value="form.credentials.api_key" placeholder="API key" />
+          </a-form-item>
+          <a-form-item label="API Secret" required>
+            <a-input-password v-model:value="form.credentials.api_secret" placeholder="API secret" />
+          </a-form-item>
+        </template>
+
+        <a-divider orientation="left" style="font-size: 13px">Sender Identity</a-divider>
+
+        <template v-if="form.channel === 'email'">
+          <a-form-item label="Sender Name" required>
+            <a-input v-model:value="form.senderIdentity.sender_name" placeholder="Company A Support" />
+          </a-form-item>
+          <a-form-item label="Sender Email" required>
+            <a-input v-model:value="form.senderIdentity.sender_email" placeholder="noreply@companya.com" />
+          </a-form-item>
+        </template>
+
+        <template v-else-if="form.channel === 'whatsapp'">
+          <a-form-item label="Phone Number ID" required>
+            <a-input v-model:value="form.senderIdentity.phone_number_id" placeholder="123456789" />
+          </a-form-item>
+          <a-form-item label="Business Account ID (WABA ID)" required>
+            <a-input v-model:value="form.senderIdentity.business_account_id" placeholder="1528784982254938" />
+          </a-form-item>
+        </template>
+
+        <template v-else-if="form.channel === 'telegram'">
+          <a-form-item label="Bot Name">
+            <a-input v-model:value="form.senderIdentity.bot_name" placeholder="CompanyA_Bot" />
+          </a-form-item>
+        </template>
+
+        <template v-else-if="form.channel === 'sms'">
+          <a-form-item label="Sender Name" required>
+            <a-input v-model:value="form.senderIdentity.sender_name" placeholder="SMSnotice" />
+          </a-form-item>
+        </template>
+
+        <a-alert
+          v-if="editingId"
+          type="info"
+          message="Leave credential fields empty to keep existing values unchanged."
+          style="margin-top: 8px"
+        />
+      </a-form>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+const BASE = `${API_URL}/api/sample-api/tenant-comms`;
+
+// ─── Channel → Provider mapping ───────────────────────────────────────────────
+
+const CHANNEL_PROVIDER_MAP = {
+  email: 'sendgrid',
+  whatsapp: 'meta',
+  telegram: 'telegram',
+  sms: 'nexmo',
+};
+
+const PROVIDER_LABELS = {
+  sendgrid: 'SendGrid',
+  meta: 'Meta (WhatsApp)',
+  telegram: 'Telegram',
+  nexmo: 'Nexmo',
+};
+
+const providerLabel = computed(() => PROVIDER_LABELS[form.value.provider] || form.value.provider);
+
+function onChannelChange(channel) {
+  form.value.provider = CHANNEL_PROVIDER_MAP[channel] || '';
+  form.value.credentials = {};
+  form.value.senderIdentity = {};
+}
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const loading = ref(false);
+const error = ref('');
+const modalVisible = ref(false);
+const submitting = ref(false);
+const editingId = ref(null);
+
+const defaultForm = () => ({
+  channel: 'email',
+  provider: 'sendgrid',
+  credentials: {},
+  senderIdentity: {},
+});
+const form = ref(defaultForm());
+
+// ─── Table columns ────────────────────────────────────────────────────────────
+
+const columns = [
+  { title: 'Channel', dataIndex: 'channel', key: 'channel', width: 100 },
+  { title: 'Provider', dataIndex: 'provider', key: 'provider', width: 100 },
+  { title: 'Sender Identity', key: 'senderIdentity', width: 200 },
+  {
+    title: 'Credentials',
+    dataIndex: 'credentials',
+    key: 'credentials',
+    width: 200,
+    customRender: ({ record }) => {
+      return Object.entries(record.credentials || {})
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(', ');
+    },
+  },
+  { title: 'Active', key: 'isActive', width: 80 },
+  { title: 'Actions', key: 'actions', width: 150 },
+];
+
+// ─── API calls ────────────────────────────────────────────────────────────────
+
+async function fetchConfigs() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const res = await fetch(BASE, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data;
+    } else {
+      error.value = data.error || 'Failed to load configs';
+    }
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function createConfig() {
+  submitting.value = true;
+  error.value = '';
+  try {
+    const body = {
+      channel: form.value.channel,
+      provider: form.value.provider,
+      credentials: form.value.credentials,
+      senderIdentity: form.value.senderIdentity,
+    };
+    const res = await fetch(BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (data.ok) {
+      modalVisible.value = false;
+      await fetchConfigs();
+    } else {
+      error.value = data.error || 'Failed to create config';
+    }
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    submitting.value = false;
+  }
+}
+
+async function updateConfig() {
+  submitting.value = true;
+  error.value = '';
+  try {
+    const body = {};
+    // Only send credentials if user entered new values
+    const creds = form.value.credentials;
+    const hasCredentials = Object.values(creds).some(v => v && v.trim() !== '');
+    if (hasCredentials) body.credentials = creds;
+
+    const identity = form.value.senderIdentity;
+    const hasIdentity = Object.values(identity).some(v => v && v.trim() !== '');
+    if (hasIdentity) body.senderIdentity = identity;
+
+    const res = await fetch(`${BASE}/${editingId.value}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (data.ok) {
+      modalVisible.value = false;
+      await fetchConfigs();
+    } else {
+      error.value = data.error || 'Failed to update config';
+    }
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    submitting.value = false;
+  }
+}
+
+async function deleteConfig(id) {
+  error.value = '';
+  try {
+    const res = await fetch(`${BASE}/${id}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    const data = await res.json();
+    if (data.ok) {
+      await fetchConfigs();
+    } else {
+      error.value = data.error || 'Failed to delete config';
+    }
+  } catch (err) {
+    error.value = err.message;
+  }
+}
+
+async function toggleActive(record) {
+  error.value = '';
+  try {
+    const res = await fetch(`${BASE}/${record.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ isActive: !record.isActive }),
+    });
+    const data = await res.json();
+    if (data.ok) {
+      await fetchConfigs();
+    } else {
+      error.value = data.error || 'Failed to toggle status';
+    }
+  } catch (err) {
+    error.value = err.message;
+  }
+}
+
+// ─── Modal helpers ────────────────────────────────────────────────────────────
+
+function showAddModal() {
+  editingId.value = null;
+  form.value = defaultForm();
+  modalVisible.value = true;
+}
+
+function showEditModal(record) {
+  editingId.value = record.id;
+  form.value = {
+    channel: record.channel,
+    provider: record.provider,
+    credentials: {}, // empty — user must re-enter to update (security)
+    senderIdentity: { ...record.senderIdentity },
+  };
+  modalVisible.value = true;
+}
+
+function handleSubmit() {
+  if (editingId.value) {
+    updateConfig();
+  } else {
+    createConfig();
+  }
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+onMounted(fetchConfigs);
+</script>
+
+<style scoped>
+.comms-config-wrap {
+  padding: 16px;
+}
+</style>

--- a/apps/sample-vue-full/views/WhatsAppBroadcast.vue
+++ b/apps/sample-vue-full/views/WhatsAppBroadcast.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="wa-broadcast-wrap">
+    <a-card title="WhatsApp Broadcast" style="max-width: 600px; margin: 40px auto">
+      <a-form layout="vertical" @submit.prevent="sendBroadcast">
+        <a-form-item label="Send from (config)">
+          <a-select
+            v-model:value="configLabel"
+            placeholder="Select a WhatsApp config"
+            style="width: 100%"
+            :loading="configsLoading"
+          >
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">
+              {{ c.label }} ({{ c.senderIdentity.phone_number_id }})
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-form-item label="Recipients (one phone number per line, with country code)">
+          <a-textarea
+            v-model:value="recipientsText"
+            :rows="4"
+            placeholder="+60123456789&#10;+60198765432&#10;+60111222333"
+          />
+          <div style="color: #888; font-size: 12px; margin-top: 4px">
+            {{ recipientCount }} recipient(s)
+          </div>
+        </a-form-item>
+
+        <a-form-item label="Message type">
+          <a-select v-model:value="type" @change="prefill" style="width: 100%">
+            <a-select-option value="text">Text</a-select-option>
+            <a-select-option value="image">Image</a-select-option>
+            <a-select-option value="document">Document</a-select-option>
+            <a-select-option value="template">Template</a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <a-form-item label="Payload (JSON)">
+          <a-textarea
+            v-model:value="payloadJson"
+            :rows="6"
+            style="font-family: monospace; font-size: 12px"
+            :status="jsonError ? 'error' : ''"
+          />
+          <div v-if="jsonError" style="color: #ff4d4f; font-size: 12px; margin-top: 4px">{{ jsonError }}</div>
+        </a-form-item>
+
+        <a-form-item>
+          <a-button type="primary" html-type="submit" :loading="loading" block>Send Broadcast</a-button>
+        </a-form-item>
+
+        <a-alert
+          v-if="result"
+          :type="result.ok ? 'success' : 'error'"
+          :message="result.ok ? `Broadcast complete: ${result.result?.sent ?? 0} sent, ${result.result?.failed ?? 0} failed` : 'Error'"
+          :description="JSON.stringify(result.result ?? result.error, null, 2)"
+          show-icon
+          style="white-space: pre-wrap; font-family: monospace; font-size: 12px"
+        />
+      </a-form>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'whatsapp');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch WhatsApp configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+onMounted(fetchConfigs);
+
+// ─── Form state ───────────────────────────────────────────────────────────────
+
+const recipientsText = ref('');
+const type = ref('text');
+const payloadJson = ref('');
+const loading = ref(false);
+const result = ref(null);
+const jsonError = ref('');
+
+const recipientCount = computed(() => {
+  return recipientsText.value
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean).length;
+});
+
+const TEMPLATES = {
+  text: { text: 'Hello from WhatsApp broadcast!' },
+  image: {
+    media: {
+      link: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png',
+    },
+    opts: { caption: 'Broadcast image' },
+  },
+  document: {
+    media: { link: 'https://www.w3.org/WAI/WCAG21/Techniques/pdf/sample.pdf' },
+    opts: { filename: 'sample.pdf', caption: 'Broadcast document' },
+  },
+  template: { opts: { name: 'hello_world', language: { code: 'en_US' }, components: [] } },
+};
+
+function prefill() {
+  payloadJson.value = JSON.stringify(TEMPLATES[type.value] ?? TEMPLATES.text, null, 2);
+}
+prefill();
+
+// ─── Send ─────────────────────────────────────────────────────────────────────
+
+async function sendBroadcast() {
+  jsonError.value = '';
+  result.value = null;
+
+  let payload;
+  try {
+    payload = JSON.parse(payloadJson.value);
+  } catch (e) {
+    jsonError.value = 'Invalid JSON';
+    return;
+  }
+
+  const recipients = recipientsText.value
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+  if (recipients.length === 0) {
+    jsonError.value = 'At least one recipient is required';
+    return;
+  }
+
+  loading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/whatsapp/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        recipients,
+        type: type.value,
+        configLabel: configLabel.value || undefined,
+        ...payload,
+      }),
+    });
+    result.value = await res.json();
+  } catch (err) {
+    result.value = { ok: false, error: err.message };
+  } finally {
+    loading.value = false;
+  }
+}
+</script>

--- a/apps/sample-vue-full/views/WhatsAppTemplates.vue
+++ b/apps/sample-vue-full/views/WhatsAppTemplates.vue
@@ -4,6 +4,9 @@
     <a-card title="WhatsApp Templates" style="max-width: 900px; margin: 40px auto">
       <template #extra>
         <a-space>
+          <a-select v-model:value="configLabel" placeholder="Select config" style="width: 200px" :loading="configsLoading" @change="loadTemplates">
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">{{ c.label }} ({{ c.senderIdentity.phone_number_id }})</a-select-option>
+          </a-select>
           <a-select v-model:value="filterStatus" style="width: 160px" @change="loadTemplates">
             <a-select-option value="">All statuses</a-select-option>
             <a-select-option value="APPROVED">Approved</a-select-option>
@@ -134,6 +137,37 @@ import { onMounted, ref } from 'vue';
 const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
 const BASE = `${API_URL}/api/sample-api/whatsapp/templates`;
 
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'whatsapp');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch WhatsApp configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+function configQs(extra = '') {
+  const params = new URLSearchParams();
+  if (configLabel.value) params.set('configLabel', configLabel.value);
+  if (extra) return `?${params}&${extra}`;
+  return params.toString() ? `?${params}` : '';
+}
+
 // ── Table ───────────────────────────────────────────────────────────────────
 const columns = [
   { title: 'Name', dataIndex: 'name', key: 'name' },
@@ -163,11 +197,12 @@ const listError = ref('');
 const filterStatus = ref('');
 
 const loadTemplates = async () => {
+  if (!configLabel.value) return;
   listLoading.value = true;
   listError.value = '';
   try {
-    const qs = filterStatus.value ? `?limit=50&status=${filterStatus.value}` : '?limit=50';
-    const res = await fetch(`${BASE}${qs}`);
+    const statusQs = filterStatus.value ? `limit=50&status=${filterStatus.value}` : 'limit=50';
+    const res = await fetch(`${BASE}${configQs(statusQs)}`, { credentials: 'include' });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
     templates.value = json.data ?? [];
@@ -178,7 +213,10 @@ const loadTemplates = async () => {
   }
 };
 
-onMounted(loadTemplates);
+onMounted(async () => {
+  await fetchConfigs();
+  if (configLabel.value) loadTemplates();
+});
 
 // ── Create / Edit modal ──────────────────────────────────────────────────────
 const modalOpen = ref(false);
@@ -255,16 +293,18 @@ const save = async () => {
   try {
     let res;
     if (editId.value) {
-      res = await fetch(`${BASE}/${editId.value}`, {
+      res = await fetch(`${BASE}/${editId.value}${configQs()}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ components }),
+        credentials: 'include',
+        body: JSON.stringify({ components, configLabel: configLabel.value }),
       });
     } else {
-      res = await fetch(BASE, {
+      res = await fetch(`${BASE}${configQs()}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...form.value, components }),
+        credentials: 'include',
+        body: JSON.stringify({ ...form.value, components, configLabel: configLabel.value }),
       });
     }
     const json = await res.json();
@@ -281,7 +321,10 @@ const save = async () => {
 // ── Delete ───────────────────────────────────────────────────────────────────
 const deleteOne = async name => {
   try {
-    const res = await fetch(`${BASE}?name=${encodeURIComponent(name)}`, { method: 'DELETE' });
+    const res = await fetch(`${BASE}${configQs(`name=${encodeURIComponent(name)}`)}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error);
     await loadTemplates();

--- a/apps/sample-vue-full/views/WhatsAppTest.vue
+++ b/apps/sample-vue-full/views/WhatsAppTest.vue
@@ -2,6 +2,12 @@
   <div class="wa-test-wrap">
     <a-card title="WhatsApp Test Sender" style="max-width: 600px; margin: 40px auto">
       <a-form layout="vertical" @submit.prevent="send">
+        <a-form-item label="Send from (config)">
+          <a-select v-model:value="configLabel" placeholder="Select a WhatsApp config" style="width: 100%" :loading="configsLoading">
+            <a-select-option v-for="c in configs" :key="c.label" :value="c.label">{{ c.label }} ({{ c.senderIdentity.phone_number_id }})</a-select-option>
+          </a-select>
+        </a-form-item>
+
         <a-row :gutter="12">
           <a-col :span="12">
             <a-form-item label="Message type">
@@ -45,9 +51,35 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 
 const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:3000';
+
+// ─── Config selector ──────────────────────────────────────────────────────────
+
+const configs = ref([]);
+const configLabel = ref('');
+const configsLoading = ref(false);
+
+async function fetchConfigs() {
+  configsLoading.value = true;
+  try {
+    const res = await fetch(`${API_URL}/api/sample-api/tenant-comms`, { credentials: 'include' });
+    const data = await res.json();
+    if (data.ok) {
+      configs.value = data.data.filter(c => c.channel === 'whatsapp');
+    }
+    if (configs.value.length > 0 && !configLabel.value) {
+      configLabel.value = configs.value[0].label;
+    }
+  } catch (err) {
+    console.error('Failed to fetch WhatsApp configs:', err);
+  } finally {
+    configsLoading.value = false;
+  }
+}
+
+onMounted(fetchConfigs);
 
 const TYPES = [
   { value: 'text', label: 'Text' },
@@ -179,7 +211,7 @@ async function send() {
     return;
   }
 
-  const payload = { type: type.value, to: to.value, ...parsed };
+  const payload = { type: type.value, to: to.value, configLabel: configLabel.value, ...parsed };
   loading.value = true;
   result.value = null;
   try {

--- a/common/compiled/node/comms/sendgrid/outbound.ts
+++ b/common/compiled/node/comms/sendgrid/outbound.ts
@@ -66,6 +66,15 @@ function applyOpts(body: Record<string, unknown>, opts: SendEmailOpts) {
   if (opts.sendAt) body.send_at = opts.sendAt;
   if (opts.batchId) body.batch_id = opts.batchId;
   if (opts.asmGroupId) body.asm = { group_id: opts.asmGroupId };
+
+  // Auto-inject tenant context into custom_args for event webhook correlation.
+  // These are returned in event webhook payloads so we can route events back to the correct config.
+  if (opts._tenantId || opts._configLabel) {
+    const existing = (body.custom_args as Record<string, string>) ?? {};
+    if (opts._tenantId) existing._novex_tenant_id = String(opts._tenantId);
+    if (opts._configLabel) existing._novex_config_label = opts._configLabel;
+    body.custom_args = existing;
+  }
 }
 
 function toAddresses(to: string | string[]) {

--- a/common/compiled/node/comms/sendgrid/outbound.ts
+++ b/common/compiled/node/comms/sendgrid/outbound.ts
@@ -1,15 +1,15 @@
 // SendGrid v3 Mail Send API — outbound helpers
 // Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
 //
-// All functions read credentials from env at call time:
-//   SENDGRID_KEY          — required for all operations
-//   SENDGRID_SENDER_NAME  — display name in From field
-//   SENDGRID_SENDER_EMAIL — From email address (must be a verified sender)
-//   SENDGRID_URL          — optional override (defaults to SendGrid global endpoint)
-//   SENDGRID_DEBUG        — set to 'true' to log every request and response body
+// All functions accept a SendGridAuth object as the first parameter.
+// The caller is responsible for providing credentials (e.g. from tenant config resolver).
+//
+// Optional env vars:
+//   SENDGRID_URL   — override the SendGrid API endpoint (defaults to global endpoint)
+//   SENDGRID_DEBUG — set to 'true' to log every request and response body
 
 import crypto from 'node:crypto';
-import type { SendEmailOpts, SgAttachment, SgPersonalization, SgSendEmailOpts } from './types.ts';
+import type { SendEmailOpts, SendGridAuth, SgAttachment, SgPersonalization, SgSendEmailOpts } from './types.ts';
 
 const BASE_URL = 'https://api.sendgrid.com/v3/mail/send';
 
@@ -36,28 +36,13 @@ function randomHash() {
   return crypto.createHash('sha256').update(Date.now().toString()).digest('hex').slice(0, 15);
 }
 
-function getApiKey(): string {
-  const key = process.env.SENDGRID_KEY;
-  if (!key) throw new Error('SENDGRID_KEY is not defined');
-  return key;
-}
-
-function getCredentials() {
-  const key = getApiKey();
-  const { SENDGRID_SENDER_NAME: senderName, SENDGRID_SENDER_EMAIL: senderEmail } = process.env;
-  if (!senderName) throw new Error('SENDGRID_SENDER_NAME is not defined');
-  if (!senderEmail) throw new Error('SENDGRID_SENDER_EMAIL is not defined');
-  return { key, senderName, senderEmail };
-}
-
-async function sgMailSend(body: Record<string, unknown>) {
-  const key = getApiKey();
+async function sgMailSend(apiKey: string, body: Record<string, unknown>) {
   const url = process.env.SENDGRID_URL ?? BASE_URL;
   sgLog('→', `POST ${url}`, body);
 
   const res = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
 
@@ -90,27 +75,27 @@ function toAddresses(to: string | string[]) {
 // ─── Outbound functions ───────────────────────────────────────────────────────
 
 /**
- * Send an HTML email. Upgraded replacement for the v1 `sendEmail` helper.
+ * Send an HTML email.
  * Supports CC/BCC, reply-to, plain text fallback, attachments, categories, tracking, and scheduling.
  *
  * @example
- * await sendEmail('user@example.com', 'Hello', '<p>World</p>');
- * await sendEmail(['a@x.com', 'b@x.com'], 'Hi', '<p>Hi</p>', { cc: [{ email: 'mgr@x.com' }] });
+ * await sendEmail(auth, 'user@example.com', 'Hello', '<p>World</p>');
+ * await sendEmail(auth, ['a@x.com', 'b@x.com'], 'Hi', '<p>Hi</p>', { cc: [{ email: 'mgr@x.com' }] });
  */
 export async function sendEmail(
+  auth: SendGridAuth,
   to: string | string[],
   subject: string,
   htmlContent: string,
   opts: SgSendEmailOpts = {},
 ) {
-  const { senderName, senderEmail } = getCredentials();
   const personalization: SgPersonalization = { to: toAddresses(to) };
   if (opts.cc?.length) personalization.cc = opts.cc;
   if (opts.bcc?.length) personalization.bcc = opts.bcc;
 
   const body: Record<string, unknown> = {
     personalizations: [personalization],
-    from: { name: senderName, email: senderEmail },
+    from: { name: auth.senderName, email: auth.senderEmail },
     subject,
     content: [
       ...(opts.plainContent ? [{ type: 'text/plain', value: opts.plainContent }] : []),
@@ -121,24 +106,23 @@ export async function sendEmail(
 
   if (opts.attachments?.length) body.attachments = opts.attachments;
   applyOpts(body, opts);
-  return sgMailSend(body);
+  return sgMailSend(auth.apiKey, body);
 }
 
 /**
  * Send an email using a stored SendGrid dynamic template (Handlebars).
- * Upgraded replacement for the v1 `sendDynamicEmail` — templateId is an explicit parameter,
- * not hardcoded from env, so different templates can be used per call.
+ * templateId is an explicit parameter so different templates can be used per call.
  *
  * @example
- * await sendDynamicEmail('user@example.com', 'd-xxxx', { firstName: 'Alice', resetLink: 'https://...' });
+ * await sendDynamicEmail(auth, 'user@example.com', 'd-xxxx', { firstName: 'Alice', resetLink: 'https://...' });
  */
 export async function sendDynamicEmail(
+  auth: SendGridAuth,
   to: string | string[],
   templateId: string,
   dynamicData: Record<string, unknown>,
   opts: SgSendEmailOpts = {},
 ) {
-  const { senderName, senderEmail } = getCredentials();
   const personalization: SgPersonalization = {
     to: toAddresses(to),
     dynamic_template_data: dynamicData,
@@ -148,13 +132,13 @@ export async function sendDynamicEmail(
 
   const body: Record<string, unknown> = {
     personalizations: [personalization],
-    from: { name: senderName, email: senderEmail },
+    from: { name: auth.senderName, email: auth.senderEmail },
     template_id: templateId,
     headers: { 'X-Entity-Ref-ID': randomHash(), ...opts.headers },
   };
   if (opts.attachments?.length) body.attachments = opts.attachments;
   applyOpts(body, opts);
-  return sgMailSend(body);
+  return sgMailSend(auth.apiKey, body);
 }
 
 /**
@@ -164,18 +148,19 @@ export async function sendDynamicEmail(
  * @example
  * import { readFileSync } from 'node:fs';
  * const content = readFileSync('./invoice.pdf').toString('base64');
- * await sendEmailWithAttachments('user@example.com', 'Invoice', '<p>See attached.</p>', [
+ * await sendEmailWithAttachments(auth, 'user@example.com', 'Invoice', '<p>See attached.</p>', [
  *   { content, filename: 'invoice.pdf', type: 'application/pdf' },
  * ]);
  */
 export async function sendEmailWithAttachments(
+  auth: SendGridAuth,
   to: string | string[],
   subject: string,
   htmlContent: string,
   attachments: SgAttachment[],
   opts: SendEmailOpts = {},
 ) {
-  return sendEmail(to, subject, htmlContent, { ...opts, attachments });
+  return sendEmail(auth, to, subject, htmlContent, { ...opts, attachments });
 }
 
 /**
@@ -183,7 +168,7 @@ export async function sendEmailWithAttachments(
  * Each personalization can override subject, add CC/BCC, or set per-recipient dynamic template data.
  *
  * @example
- * await sendBulkEmail(
+ * await sendBulkEmail(auth,
  *   [
  *     { to: [{ email: 'alice@example.com' }], dynamic_template_data: { name: 'Alice' } },
  *     { to: [{ email: 'bob@example.com' }], dynamic_template_data: { name: 'Bob' } },
@@ -193,15 +178,15 @@ export async function sendEmailWithAttachments(
  * );
  */
 export async function sendBulkEmail(
+  auth: SendGridAuth,
   personalizations: SgPersonalization[],
   subject: string,
   htmlContent: string,
   opts: SgSendEmailOpts = {},
 ) {
-  const { senderName, senderEmail } = getCredentials();
   const body: Record<string, unknown> = {
     personalizations,
-    from: { name: senderName, email: senderEmail },
+    from: { name: auth.senderName, email: auth.senderEmail },
     subject,
     content: [
       ...(opts.plainContent ? [{ type: 'text/plain', value: opts.plainContent }] : []),
@@ -211,7 +196,7 @@ export async function sendBulkEmail(
   };
   if (opts.attachments?.length) body.attachments = opts.attachments;
   applyOpts(body, opts);
-  return sgMailSend(body);
+  return sgMailSend(auth.apiKey, body);
 }
 
 /**
@@ -219,25 +204,25 @@ export async function sendBulkEmail(
  * Each personalization can have its own dynamic_template_data, CC/BCC, and subject override.
  *
  * @example
- * await sendBulkDynamicEmail('d-xxxx', [
+ * await sendBulkDynamicEmail(auth, 'd-xxxx', [
  *   { to: [{ email: 'alice@example.com' }], dynamic_template_data: { name: 'Alice' } },
  *   { to: [{ email: 'bob@example.com' }], dynamic_template_data: { name: 'Bob' } },
  * ]);
  */
 export async function sendBulkDynamicEmail(
+  auth: SendGridAuth,
   templateId: string,
   personalizations: SgPersonalization[],
   opts: SendEmailOpts = {},
 ) {
-  const { senderName, senderEmail } = getCredentials();
   const body: Record<string, unknown> = {
     personalizations,
-    from: { name: senderName, email: senderEmail },
+    from: { name: auth.senderName, email: auth.senderEmail },
     template_id: templateId,
     headers: { 'X-Entity-Ref-ID': randomHash(), ...opts.headers },
   };
   applyOpts(body, opts);
-  return sgMailSend(body);
+  return sgMailSend(auth.apiKey, body);
 }
 
 /**
@@ -248,17 +233,18 @@ export async function sendBulkDynamicEmail(
  *
  * @example
  * const inOneHour = Math.floor(Date.now() / 1000) + 3600;
- * const { batchId } = await sendScheduledEmail('user@example.com', 'Reminder', '<p>Hi</p>', inOneHour);
+ * const { batchId } = await sendScheduledEmail(auth, 'user@example.com', 'Reminder', '<p>Hi</p>', inOneHour);
  */
 export async function sendScheduledEmail(
+  auth: SendGridAuth,
   to: string | string[],
   subject: string,
   htmlContent: string,
   sendAt: number,
   opts: SgSendEmailOpts = {},
 ) {
-  const batchId = opts.batchId ?? (await generateBatchId());
-  await sendEmail(to, subject, htmlContent, { ...opts, sendAt, batchId });
+  const batchId = opts.batchId ?? (await generateBatchId(auth));
+  await sendEmail(auth, to, subject, htmlContent, { ...opts, sendAt, batchId });
   return { batchId };
 }
 
@@ -270,18 +256,19 @@ export async function sendScheduledEmail(
  *
  * @example
  * const inOneHour = Math.floor(Date.now() / 1000) + 3600;
- * const { batchId } = await sendScheduledDynamicEmail('user@example.com', 'd-xxxx', { name: 'Alice' }, inOneHour);
- * // Later: await cancelScheduledEmail(batchId);
+ * const { batchId } = await sendScheduledDynamicEmail(auth, 'user@example.com', 'd-xxxx', { name: 'Alice' }, inOneHour);
+ * // Later: await cancelScheduledEmail(auth, batchId);
  */
 export async function sendScheduledDynamicEmail(
+  auth: SendGridAuth,
   to: string | string[],
   templateId: string,
   dynamicData: Record<string, unknown>,
   sendAt: number,
   opts: SgSendEmailOpts = {},
 ) {
-  const batchId = opts.batchId ?? (await generateBatchId());
-  await sendDynamicEmail(to, templateId, dynamicData, { ...opts, sendAt, batchId });
+  const batchId = opts.batchId ?? (await generateBatchId(auth));
+  await sendDynamicEmail(auth, to, templateId, dynamicData, { ...opts, sendAt, batchId });
   return { batchId };
 }
 
@@ -290,17 +277,16 @@ export async function sendScheduledDynamicEmail(
  * Only works before the scheduled send_at time arrives.
  *
  * @example
- * await cancelScheduledEmail(batchId);
+ * await cancelScheduledEmail(auth, batchId);
  */
-export async function cancelScheduledEmail(batchId: string) {
-  const key = getApiKey();
+export async function cancelScheduledEmail(auth: SendGridAuth, batchId: string) {
   const url = 'https://api.sendgrid.com/v3/user/scheduled_sends';
   const payload = { batch_id: batchId, status: 'cancel' };
   sgLog('→', `POST ${url}`, payload);
 
   const res = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: `Bearer ${auth.apiKey}`, 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
 
@@ -319,21 +305,20 @@ export async function cancelScheduledEmail(batchId: string) {
 /**
  * Generate a SendGrid batch ID for use with scheduled sends.
  * Pass the returned ID as `opts.batchId` to any send function along with `opts.sendAt`,
- * then use `cancelScheduledEmail(batchId)` to cancel before delivery.
+ * then use `cancelScheduledEmail(auth, batchId)` to cancel before delivery.
  *
  * @example
- * const batchId = await generateBatchId();
- * await sendDynamicEmail(to, templateId, data, { sendAt: inOneHour, batchId });
- * // Later: await cancelScheduledEmail(batchId);
+ * const batchId = await generateBatchId(auth);
+ * await sendDynamicEmail(auth, to, templateId, data, { sendAt: inOneHour, batchId });
+ * // Later: await cancelScheduledEmail(auth, batchId);
  */
-export async function generateBatchId(): Promise<string> {
-  const key = getApiKey();
+export async function generateBatchId(auth: SendGridAuth): Promise<string> {
   const url = 'https://api.sendgrid.com/v3/mail/batch';
   sgLog('→', `POST ${url}`, {});
 
   const res = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: `Bearer ${auth.apiKey}`, 'Content-Type': 'application/json' },
   });
 
   const data = (await res.json()) as { batch_id?: string };

--- a/common/compiled/node/comms/sendgrid/template.ts
+++ b/common/compiled/node/comms/sendgrid/template.ts
@@ -1,8 +1,8 @@
 // SendGrid v3 Dynamic Templates API — template management helpers
 // Docs: https://docs.sendgrid.com/api-reference/transactional-templates/
 //
-// Uses the same SENDGRID_KEY as outbound.ts — no additional env vars needed.
-// All template IDs start with d- (dynamic generation).
+// All functions accept an apiKey as the first parameter.
+// The caller is responsible for providing credentials (e.g. from tenant config resolver).
 
 import type { SgTemplate, SgTemplateVersion, SgTemplateVersionData } from './types.ts';
 
@@ -24,22 +24,16 @@ export class SgTemplateError extends Error {
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
-function getApiKey(): string {
-  const key = process.env.SENDGRID_KEY;
-  if (!key) throw new Error('SENDGRID_KEY is not defined');
-  return key;
-}
-
 async function tmplRequest<T>(
+  apiKey: string,
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
   path: string,
   body?: Record<string, unknown>,
 ): Promise<T> {
-  const key = getApiKey();
   const res = await fetch(`${BASE}${path}`, {
     method,
     headers: {
-      Authorization: `Bearer ${key}`,
+      Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
     },
     body: body ? JSON.stringify(body) : undefined,
@@ -63,81 +57,88 @@ async function tmplRequest<T>(
 
 /**
  * List all dynamic templates (paginated).
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates/retrieve-paged-transactional-templates
  */
-export async function listTemplates(opts: { pageSize?: number; pageToken?: string } = {}): Promise<{
+export async function listTemplates(
+  apiKey: string,
+  opts: { pageSize?: number; pageToken?: string } = {},
+): Promise<{
   templates: SgTemplate[];
   _metadata?: { self: string; next?: string; prev?: string; count: number };
 }> {
   const params = new URLSearchParams({ generations: 'dynamic' });
   if (opts.pageSize) params.set('page_size', String(opts.pageSize));
   if (opts.pageToken) params.set('page_token', opts.pageToken);
-  return tmplRequest('GET', `/templates?${params}`);
+  return tmplRequest(apiKey, 'GET', `/templates?${params}`);
 }
 
 /**
  * Get a single template with all its versions.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates/retrieve-a-single-transactional-template
  */
-export async function getTemplate(templateId: string): Promise<SgTemplate> {
-  return tmplRequest('GET', `/templates/${templateId}`);
+export async function getTemplate(apiKey: string, templateId: string): Promise<SgTemplate> {
+  return tmplRequest(apiKey, 'GET', `/templates/${templateId}`);
 }
 
 /**
  * Create a new empty dynamic template.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates/create-a-transactional-template
  */
-export async function createTemplate(name: string, generation: 'dynamic' | 'legacy' = 'dynamic'): Promise<SgTemplate> {
-  return tmplRequest('POST', '/templates', { name, generation });
+export async function createTemplate(
+  apiKey: string,
+  name: string,
+  generation: 'dynamic' | 'legacy' = 'dynamic',
+): Promise<SgTemplate> {
+  return tmplRequest(apiKey, 'POST', '/templates', { name, generation });
 }
 
 /**
  * Rename an existing template.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates/edit-a-transactional-template
  */
-export async function updateTemplate(templateId: string, name: string): Promise<SgTemplate> {
-  return tmplRequest('PATCH', `/templates/${templateId}`, { name });
+export async function updateTemplate(apiKey: string, templateId: string, name: string): Promise<SgTemplate> {
+  return tmplRequest(apiKey, 'PATCH', `/templates/${templateId}`, { name });
 }
 
 /**
  * Duplicate a template (clones the template shell and its active version).
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates/duplicate-a-transactional-template
  */
-export async function duplicateTemplate(templateId: string, name?: string): Promise<SgTemplate> {
-  return tmplRequest('POST', `/templates/${templateId}`, name ? { name } : {});
+export async function duplicateTemplate(apiKey: string, templateId: string, name?: string): Promise<SgTemplate> {
+  return tmplRequest(apiKey, 'POST', `/templates/${templateId}`, name ? { name } : {});
 }
 
 /**
  * Permanently delete a template and all its versions.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates/delete-a-template
  */
-export async function deleteTemplate(templateId: string): Promise<void> {
-  await tmplRequest('DELETE', `/templates/${templateId}`);
+export async function deleteTemplate(apiKey: string, templateId: string): Promise<void> {
+  await tmplRequest(apiKey, 'DELETE', `/templates/${templateId}`);
 }
 
 // ─── Version CRUD ─────────────────────────────────────────────────────────────
 
 /**
  * Create a new version for a template.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates-versions-unsubscribe-actions/create-a-new-transactional-template-version
  */
 export async function createTemplateVersion(
+  apiKey: string,
   templateId: string,
   versionData: SgTemplateVersionData,
 ): Promise<SgTemplateVersion> {
-  return tmplRequest('POST', `/templates/${templateId}/versions`, versionData as unknown as Record<string, unknown>);
+  return tmplRequest(
+    apiKey,
+    'POST',
+    `/templates/${templateId}/versions`,
+    versionData as unknown as Record<string, unknown>,
+  );
 }
 
 /**
  * Update a version's name, subject, HTML or plain content.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates-versions-unsubscribe-actions/edit-a-transactional-template-version
  */
 export async function updateTemplateVersion(
+  apiKey: string,
   templateId: string,
   versionId: string,
   versionData: Partial<SgTemplateVersionData>,
 ): Promise<SgTemplateVersion> {
   return tmplRequest(
+    apiKey,
     'PATCH',
     `/templates/${templateId}/versions/${versionId}`,
     versionData as unknown as Record<string, unknown>,
@@ -146,16 +147,18 @@ export async function updateTemplateVersion(
 
 /**
  * Activate a version — makes it the live version referenced when sending with this templateId.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates-versions-unsubscribe-actions/activate-a-transactional-template-version
  */
-export async function activateTemplateVersion(templateId: string, versionId: string): Promise<SgTemplateVersion> {
-  return tmplRequest('POST', `/templates/${templateId}/versions/${versionId}/activate`);
+export async function activateTemplateVersion(
+  apiKey: string,
+  templateId: string,
+  versionId: string,
+): Promise<SgTemplateVersion> {
+  return tmplRequest(apiKey, 'POST', `/templates/${templateId}/versions/${versionId}/activate`);
 }
 
 /**
  * Permanently delete a template version.
- * Docs: https://docs.sendgrid.com/api-reference/transactional-templates-versions-unsubscribe-actions/delete-a-transactional-template-version
  */
-export async function deleteTemplateVersion(templateId: string, versionId: string): Promise<void> {
-  await tmplRequest('DELETE', `/templates/${templateId}/versions/${versionId}`);
+export async function deleteTemplateVersion(apiKey: string, templateId: string, versionId: string): Promise<void> {
+  await tmplRequest(apiKey, 'DELETE', `/templates/${templateId}/versions/${versionId}`);
 }

--- a/common/compiled/node/comms/sendgrid/types.ts
+++ b/common/compiled/node/comms/sendgrid/types.ts
@@ -1,6 +1,15 @@
 // SendGrid v3 Mail Send API — shared types
 // Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
 
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+/** Credentials required for all SendGrid operations. */
+export interface SendGridAuth {
+  apiKey: string;
+  senderName: string;
+  senderEmail: string;
+}
+
 // ─── Outbound ─────────────────────────────────────────────────────────────────
 
 export interface SgEmailAddress {

--- a/common/compiled/node/comms/sendgrid/types.ts
+++ b/common/compiled/node/comms/sendgrid/types.ts
@@ -91,6 +91,12 @@ export interface SendEmailOpts {
   batchId?: string;
   /** Unsubscribe group ID (SendGrid Suppression Groups) */
   asmGroupId?: number;
+
+  // ── Tenant context (auto-injected into custom_args for event webhook correlation) ──
+  /** Tenant ID — injected as _novex_tenant_id in custom_args */
+  _tenantId?: number;
+  /** Config label — injected as _novex_config_label in custom_args */
+  _configLabel?: string;
 }
 
 /** Extends SendEmailOpts with file attachments support. */

--- a/common/compiled/node/comms/service/broadcast.ts
+++ b/common/compiled/node/comms/service/broadcast.ts
@@ -1,0 +1,84 @@
+// Unified comms service — broadcast (multi-recipient send)
+
+import { send } from './send.ts';
+import type { BroadcastRecipientResult, BroadcastRequest, BroadcastResult } from './types.ts';
+
+/**
+ * Send the same message to multiple recipients.
+ * Supports sequential (with delay) and concurrent (batched) modes.
+ *
+ * @example
+ * import { broadcast } from '@common/node/comms/service/broadcast'
+ *
+ * const result = await broadcast({
+ *   tenantId: 1,
+ *   channel: 'whatsapp',
+ *   recipients: ['+60111', '+60222', '+60333'],
+ *   type: 'template',
+ *   payload: { opts: { name: 'promo_blast', language: { code: 'en' }, components: [] } },
+ *   options: { mode: 'sequential', delayMs: 1000 },
+ * })
+ *
+ * console.log(result.sent, result.failed) // 3, 0
+ */
+export async function broadcast(req: BroadcastRequest): Promise<BroadcastResult> {
+  const { recipients, options, ...sendParams } = req;
+  const mode = options?.mode ?? 'sequential';
+  const delayMs = options?.delayMs ?? 0;
+  const concurrency = options?.concurrency ?? 5;
+
+  const results: BroadcastRecipientResult[] = [];
+
+  if (mode === 'sequential') {
+    for (const to of recipients) {
+      const result = await send({ ...sendParams, to });
+      results.push({ to, success: result.success, messageId: result.messageId, error: result.error });
+
+      if (delayMs > 0) {
+        await delay(delayMs);
+      }
+    }
+  } else {
+    // Concurrent mode — process in batches of `concurrency`
+    for (let i = 0; i < recipients.length; i += concurrency) {
+      const batch = recipients.slice(i, i + concurrency);
+      const batchResults = await Promise.allSettled(batch.map(to => send({ ...sendParams, to })));
+
+      for (let j = 0; j < batch.length; j++) {
+        const settled = batchResults[j];
+        if (settled.status === 'fulfilled') {
+          results.push({
+            to: batch[j],
+            success: settled.value.success,
+            messageId: settled.value.messageId,
+            error: settled.value.error,
+          });
+        } else {
+          results.push({
+            to: batch[j],
+            success: false,
+            error: settled.reason?.message ?? 'Unknown error',
+          });
+        }
+      }
+    }
+  }
+
+  const sent = results.filter(r => r.success).length;
+  const failed = results.filter(r => !r.success).length;
+
+  return {
+    success: failed === 0,
+    channel: req.channel,
+    total: recipients.length,
+    sent,
+    failed,
+    results,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/common/compiled/node/comms/service/broadcast.ts
+++ b/common/compiled/node/comms/service/broadcast.ts
@@ -1,7 +1,7 @@
 // Unified comms service — broadcast (multi-recipient send)
 
 import { send } from './send.ts';
-import type { BroadcastRecipientResult, BroadcastRequest, BroadcastResult } from './types.ts';
+import type { BroadcastRecipientResult, BroadcastRequest, BroadcastResult, SendRequest } from './types.ts';
 
 /**
  * Send the same message to multiple recipients.
@@ -31,7 +31,7 @@ export async function broadcast(req: BroadcastRequest): Promise<BroadcastResult>
 
   if (mode === 'sequential') {
     for (const to of recipients) {
-      const result = await send({ ...sendParams, to });
+      const result = await send({ ...sendParams, to } as SendRequest);
       results.push({ to, success: result.success, messageId: result.messageId, error: result.error });
 
       if (delayMs > 0) {
@@ -42,7 +42,7 @@ export async function broadcast(req: BroadcastRequest): Promise<BroadcastResult>
     // Concurrent mode — process in batches of `concurrency`
     for (let i = 0; i < recipients.length; i += concurrency) {
       const batch = recipients.slice(i, i + concurrency);
-      const batchResults = await Promise.allSettled(batch.map(to => send({ ...sendParams, to })));
+      const batchResults = await Promise.allSettled(batch.map(to => send({ ...sendParams, to } as SendRequest)));
 
       for (let j = 0; j < batch.length; j++) {
         const settled = batchResults[j];

--- a/common/compiled/node/comms/service/broadcast.ts
+++ b/common/compiled/node/comms/service/broadcast.ts
@@ -1,5 +1,6 @@
 // Unified comms service — broadcast (multi-recipient send)
 
+import { sleep } from '@common/iso/sleep';
 import { send } from './send.ts';
 import type { BroadcastRecipientResult, BroadcastRequest, BroadcastResult, SendRequest } from './types.ts';
 
@@ -35,7 +36,7 @@ export async function broadcast(req: BroadcastRequest): Promise<BroadcastResult>
       results.push({ to, success: result.success, messageId: result.messageId, error: result.error });
 
       if (delayMs > 0) {
-        await delay(delayMs);
+        await sleep(delayMs);
       }
     }
   } else {
@@ -75,10 +76,4 @@ export async function broadcast(req: BroadcastRequest): Promise<BroadcastResult>
     failed,
     results,
   };
-}
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/common/compiled/node/comms/service/send.ts
+++ b/common/compiled/node/comms/service/send.ts
@@ -26,6 +26,7 @@ import {
   sendVoice,
 } from '../telegram2/outbound.ts';
 import { configure, isConfigured, resolveCommsCredentials, setup } from '../tenant/resolver.ts';
+import type { CommsChannel } from '../tenant/types.ts';
 import {
   sendAddressRequest,
   sendButtons,
@@ -42,7 +43,7 @@ import {
   sendSticker as waSendSticker,
   sendVideo as waSendVideo,
 } from '../whatsapp2/outbound.ts';
-import type { SendRequest, SendResult } from './types.ts';
+import type { EmailSendRequest, SendRequest, SendResult, TelegramSendRequest, WhatsAppSendRequest } from './types.ts';
 
 // ─── Initialization ───────────────────────────────────────────────────────────
 
@@ -68,12 +69,31 @@ export function init(opts: { table: unknown; serviceName?: string; lookup: (name
  * Unified send function — resolves credentials and dispatches to the correct channel.
  * Covers sending NEW messages to a single recipient. For multi-recipient, use broadcast().
  *
- * @example
- * import { send } from '@common/node/comms/service/send'
+ * The `payload` type is narrowed automatically based on `channel` + `type`.
  *
- * await send({ tenantId: 1, channel: 'telegram', to: '12345', type: 'text', payload: { text: 'Hi' } })
- * await send({ tenantId: 1, channel: 'whatsapp', to: '+60123', type: 'text', payload: { text: 'Hi' } })
- * await send({ tenantId: 1, channel: 'email', to: 'a@b.com', type: 'html', payload: { subject: 'Hi', html: '<p>Hi</p>' } })
+ * @example Telegram text
+ * await send({ tenantId: 1, channel: 'telegram', to: '12345678', type: 'text', payload: { text: 'Hello!' } })
+ *
+ * @example Telegram photo
+ * await send({ tenantId: 1, channel: 'telegram', to: '12345678', type: 'photo', payload: { photo: 'https://example.com/img.jpg', opts: { caption: 'A photo' } } })
+ *
+ * @example WhatsApp text
+ * await send({ tenantId: 1, channel: 'whatsapp', to: '+60123456789', type: 'text', payload: { text: 'Hello!' } })
+ *
+ * @example WhatsApp image
+ * await send({ tenantId: 1, channel: 'whatsapp', to: '+60123456789', type: 'image', payload: { media: { link: 'https://example.com/img.jpg' }, caption: 'Check this out' } })
+ *
+ * @example WhatsApp buttons
+ * await send({ tenantId: 1, channel: 'whatsapp', to: '+60123456789', type: 'buttons', payload: { body: 'Choose:', buttons: [{ id: 'yes', title: 'Yes' }, { id: 'no', title: 'No' }] } })
+ *
+ * @example WhatsApp template
+ * await send({ tenantId: 1, channel: 'whatsapp', to: '+60123456789', type: 'template', payload: { name: 'hello_world', language: 'en_US' } })
+ *
+ * @example Email HTML
+ * await send({ tenantId: 1, channel: 'email', to: 'user@example.com', type: 'html', payload: { subject: 'Hello', html: '<p>Hi there</p>' } })
+ *
+ * @example Email dynamic template
+ * await send({ tenantId: 1, channel: 'email', to: 'user@example.com', type: 'dynamic', payload: { templateId: 'd-abc123', dynamicData: { name: 'Alice' } } })
  */
 export async function send(req: SendRequest): Promise<SendResult> {
   if (!isConfigured()) {
@@ -95,15 +115,20 @@ export async function send(req: SendRequest): Promise<SendResult> {
       return sendWhatsApp(config.credentials, config.senderIdentity, req);
     case 'email':
       return sendSendGrid(config.credentials, config.senderIdentity, req);
-    default:
-      return { success: false, channel: req.channel, error: `Unsupported channel: ${req.channel}` };
+    default: {
+      // biome-ignore lint/suspicious/noExplicitAny: exhaustive guard — req is never in strict channel union
+      const ch = (req as any).channel as string;
+      return { success: false, channel: ch as CommsChannel, error: `Unsupported channel: ${ch}` };
+    }
   }
 }
 
 // ─── Telegram Dispatcher ──────────────────────────────────────────────────────
 
-async function sendTelegram(token: string, req: SendRequest): Promise<SendResult> {
-  const { to, type, payload } = req;
+async function sendTelegram(token: string, req: TelegramSendRequest): Promise<SendResult> {
+  const { to, type } = req;
+  // biome-ignore lint/suspicious/noExplicitAny: internal dispatcher requires runtime flexibility for test routes
+  const payload = req.payload as Record<string, any>;
   let result: any;
   // The payload itself serves as opts (parse_mode, caption, reply_markup, etc. are top-level fields)
   const opts = payload.opts ?? payload;
@@ -167,9 +192,11 @@ async function sendTelegram(token: string, req: SendRequest): Promise<SendResult
 async function sendWhatsApp(
   credentials: Record<string, string>,
   identity: Record<string, string>,
-  req: SendRequest,
+  req: WhatsAppSendRequest,
 ): Promise<SendResult> {
-  const { to, type, payload } = req;
+  const { to, type } = req;
+  // biome-ignore lint/suspicious/noExplicitAny: internal dispatcher requires runtime flexibility for test routes
+  const payload = req.payload as Record<string, any>;
   const token = credentials.token;
   const phoneNumberId = identity.phone_number_id;
   let result: any;
@@ -261,9 +288,11 @@ async function sendWhatsApp(
 async function sendSendGrid(
   credentials: Record<string, string>,
   identity: Record<string, string>,
-  req: SendRequest,
+  req: EmailSendRequest,
 ): Promise<SendResult> {
-  const { to, type, payload } = req;
+  const { to, type } = req;
+  // biome-ignore lint/suspicious/noExplicitAny: internal dispatcher requires runtime flexibility for test routes
+  const payload = req.payload as Record<string, any>;
   const auth: SendGridAuth = {
     apiKey: credentials.api_key,
     senderName: identity.sender_name,

--- a/common/compiled/node/comms/service/send.ts
+++ b/common/compiled/node/comms/service/send.ts
@@ -1,0 +1,305 @@
+// Unified comms service — send dispatcher
+// Resolves credentials and dispatches to the correct channel library.
+
+import {
+  sendDynamicEmail,
+  sendEmail,
+  sendEmailWithAttachments,
+  sendScheduledDynamicEmail,
+  sendScheduledEmail,
+} from '../sendgrid/outbound.ts';
+import type { SendGridAuth } from '../sendgrid/types.ts';
+import {
+  sendAnimation,
+  sendAudio,
+  sendContact,
+  sendDice,
+  sendDocument,
+  sendLocation,
+  sendMessage,
+  sendPhoto,
+  sendPoll,
+  sendSticker,
+  sendVenue,
+  sendVideo,
+  sendVideoNote,
+  sendVoice,
+} from '../telegram2/outbound.ts';
+import { configure, isConfigured, resolveCommsCredentials, setup } from '../tenant/resolver.ts';
+import {
+  sendAddressRequest,
+  sendButtons,
+  sendContacts,
+  sendCtaUrlButton,
+  sendFlow,
+  sendImage,
+  sendList,
+  sendTemplate,
+  sendText,
+  sendAudio as waSendAudio,
+  sendDocument as waSendDoc,
+  sendLocation as waSendLocation,
+  sendSticker as waSendSticker,
+  sendVideo as waSendVideo,
+} from '../whatsapp2/outbound.ts';
+import type { SendRequest, SendResult } from './types.ts';
+
+// ─── Initialization ───────────────────────────────────────────────────────────
+
+/**
+ * Initialize the comms service module. Call once at app startup.
+ * This replaces the need to call configure() + setup() on the tenant resolver directly.
+ *
+ * @example
+ * import { init } from '@common/node/comms/service/send'
+ * import { tenantCommsConfig } from './database/schema-iam.ts'
+ * import * as services from '@common/node/services'
+ *
+ * init({ table: tenantCommsConfig, serviceName: 'drizzle1', lookup: services.get })
+ */
+export function init(opts: { table: unknown; serviceName?: string; lookup: (name: string) => unknown }) {
+  configure({ tenantCommsConfig: opts.table });
+  setup(opts.serviceName ?? 'drizzle1', opts.lookup);
+}
+
+// ─── Send ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Unified send function — resolves credentials and dispatches to the correct channel.
+ * Covers sending NEW messages to a single recipient. For multi-recipient, use broadcast().
+ *
+ * @example
+ * import { send } from '@common/node/comms/service/send'
+ *
+ * await send({ tenantId: 1, channel: 'telegram', to: '12345', type: 'text', payload: { text: 'Hi' } })
+ * await send({ tenantId: 1, channel: 'whatsapp', to: '+60123', type: 'text', payload: { text: 'Hi' } })
+ * await send({ tenantId: 1, channel: 'email', to: 'a@b.com', type: 'html', payload: { subject: 'Hi', html: '<p>Hi</p>' } })
+ */
+export async function send(req: SendRequest): Promise<SendResult> {
+  if (!isConfigured()) {
+    throw new Error(
+      'Comms service not initialized. Call init() once in your app.ts:\n\n' +
+        "  import { init } from '@common/node/comms/service/send'\n" +
+        "  import { tenantCommsConfig } from './database/schema-iam.ts'\n" +
+        "  import * as services from '@common/node/services'\n\n" +
+        "  init({ table: tenantCommsConfig, serviceName: 'drizzle1', lookup: services.get })\n",
+    );
+  }
+
+  const config = await resolveCommsCredentials(req.tenantId, req.channel, req.configLabel);
+
+  switch (req.channel) {
+    case 'telegram':
+      return sendTelegram(config.credentials.bot_token, req);
+    case 'whatsapp':
+      return sendWhatsApp(config.credentials, config.senderIdentity, req);
+    case 'email':
+      return sendSendGrid(config.credentials, config.senderIdentity, req);
+    default:
+      return { success: false, channel: req.channel, error: `Unsupported channel: ${req.channel}` };
+  }
+}
+
+// ─── Telegram Dispatcher ──────────────────────────────────────────────────────
+
+async function sendTelegram(token: string, req: SendRequest): Promise<SendResult> {
+  const { to, type, payload } = req;
+  let result: any;
+  // The payload itself serves as opts (parse_mode, caption, reply_markup, etc. are top-level fields)
+  const opts = payload.opts ?? payload;
+
+  try {
+    switch (type) {
+      case 'text':
+        result = await sendMessage(token, to, String(payload.text ?? ''), opts);
+        break;
+      case 'photo':
+        result = await sendPhoto(token, to, String(payload.photo ?? ''), opts);
+        break;
+      case 'video':
+        result = await sendVideo(token, to, String(payload.video ?? ''), opts);
+        break;
+      case 'audio':
+        result = await sendAudio(token, to, String(payload.audio ?? ''), opts);
+        break;
+      case 'document':
+        result = await sendDocument(token, to, String(payload.document ?? ''), opts);
+        break;
+      case 'voice':
+        result = await sendVoice(token, to, String(payload.voice ?? ''), opts);
+        break;
+      case 'video_note':
+        result = await sendVideoNote(token, to, String(payload.video_note ?? payload.videoNote ?? ''), opts);
+        break;
+      case 'sticker':
+        result = await sendSticker(token, to, String(payload.sticker ?? ''), opts);
+        break;
+      case 'animation':
+        result = await sendAnimation(token, to, String(payload.animation ?? ''), opts);
+        break;
+      case 'location':
+        result = await sendLocation(token, to, Number(payload.latitude), Number(payload.longitude), opts);
+        break;
+      case 'venue':
+        result = await sendVenue(token, to, payload.venue, opts);
+        break;
+      case 'contact':
+        result = await sendContact(token, to, payload.contact, opts);
+        break;
+      case 'poll':
+        result = await sendPoll(token, to, String(payload.question ?? ''), payload.options ?? [], opts);
+        break;
+      case 'dice':
+        result = await sendDice(token, to, typeof payload.emoji === 'string' ? payload.emoji : '🎲', opts);
+        break;
+      default:
+        return { success: false, channel: 'telegram', error: `Unsupported telegram type: ${type}` };
+    }
+
+    return { success: true, channel: 'telegram', messageId: String(result?.message_id ?? '') };
+  } catch (err: any) {
+    return { success: false, channel: 'telegram', error: err.message ?? String(err) };
+  }
+}
+
+// ─── WhatsApp Dispatcher ──────────────────────────────────────────────────────
+
+async function sendWhatsApp(
+  credentials: Record<string, string>,
+  identity: Record<string, string>,
+  req: SendRequest,
+): Promise<SendResult> {
+  const { to, type, payload } = req;
+  const token = credentials.token;
+  const phoneNumberId = identity.phone_number_id;
+  let result: any;
+
+  try {
+    switch (type) {
+      case 'text':
+        // Accept both { text: "..." } and { body: "..." } (test page sends body)
+        result = await sendText(token, phoneNumberId, to, String(payload.text ?? payload.body ?? ''), payload.opts);
+        break;
+      case 'image':
+      case 'audio':
+      case 'video':
+      case 'sticker':
+      case 'document': {
+        // Accept both { media: { id/link } } and flat { id, link } (test page sends flat)
+        const media = payload.media ?? (payload.id ? { id: payload.id } : payload.link ? { link: payload.link } : {});
+        const mediaOpts = payload.opts ?? {};
+        if (payload.caption) mediaOpts.caption = payload.caption;
+        if (payload.filename) mediaOpts.filename = payload.filename;
+        switch (type) {
+          case 'image':
+            result = await sendImage(token, phoneNumberId, to, media, mediaOpts);
+            break;
+          case 'audio':
+            result = await waSendAudio(token, phoneNumberId, to, media, mediaOpts);
+            break;
+          case 'video':
+            result = await waSendVideo(token, phoneNumberId, to, media, mediaOpts);
+            break;
+          case 'sticker':
+            result = await waSendSticker(token, phoneNumberId, to, media, mediaOpts);
+            break;
+          case 'document':
+            result = await waSendDoc(token, phoneNumberId, to, media, mediaOpts);
+            break;
+        }
+        break;
+      }
+      case 'location':
+        // Accept both { location: { latitude, longitude } } and flat { latitude, longitude }
+        result = await waSendLocation(
+          token,
+          phoneNumberId,
+          to,
+          payload.location ?? {
+            latitude: Number(payload.latitude),
+            longitude: Number(payload.longitude),
+            name: payload.name,
+            address: payload.address,
+          },
+          payload.opts,
+        );
+        break;
+      case 'contacts':
+        result = await sendContacts(token, phoneNumberId, to, payload.contacts, payload.opts);
+        break;
+      case 'template':
+        // Accept both { opts: { name, language, components } } and flat { name, language, components }
+        result = await sendTemplate(token, phoneNumberId, to, payload.opts ?? payload);
+        break;
+      case 'buttons':
+        result = await sendButtons(token, phoneNumberId, to, payload.opts ?? payload);
+        break;
+      case 'list':
+        result = await sendList(token, phoneNumberId, to, payload.opts ?? payload);
+        break;
+      case 'cta_url':
+        result = await sendCtaUrlButton(token, phoneNumberId, to, payload.opts ?? payload);
+        break;
+      case 'address_request':
+        result = await sendAddressRequest(token, phoneNumberId, to, payload.opts ?? payload);
+        break;
+      case 'flow':
+        result = await sendFlow(token, phoneNumberId, to, payload.opts ?? payload);
+        break;
+      default:
+        return { success: false, channel: 'whatsapp', error: `Unsupported whatsapp type: ${type}` };
+    }
+
+    return { success: true, channel: 'whatsapp', messageId: result?.messages?.[0]?.id ?? '' };
+  } catch (err: any) {
+    return { success: false, channel: 'whatsapp', error: err.message ?? String(err) };
+  }
+}
+
+// ─── Email (SendGrid) Dispatcher ──────────────────────────────────────────────
+
+async function sendSendGrid(
+  credentials: Record<string, string>,
+  identity: Record<string, string>,
+  req: SendRequest,
+): Promise<SendResult> {
+  const { to, type, payload } = req;
+  const auth: SendGridAuth = {
+    apiKey: credentials.api_key,
+    senderName: identity.sender_name,
+    senderEmail: identity.sender_email,
+  };
+
+  try {
+    switch (type) {
+      case 'html':
+        await sendEmail(auth, to, payload.subject, payload.html, payload.opts);
+        break;
+      case 'dynamic':
+        await sendDynamicEmail(auth, to, payload.templateId, payload.dynamicData, payload.opts);
+        break;
+      case 'html_attachments':
+        await sendEmailWithAttachments(auth, to, payload.subject, payload.html, payload.attachments, payload.opts);
+        break;
+      case 'scheduled':
+        await sendScheduledEmail(auth, to, payload.subject, payload.html, payload.sendAt, payload.opts);
+        break;
+      case 'scheduled_dynamic':
+        await sendScheduledDynamicEmail(
+          auth,
+          to,
+          payload.templateId,
+          payload.dynamicData,
+          payload.sendAt,
+          payload.opts,
+        );
+        break;
+      default:
+        return { success: false, channel: 'email', error: `Unsupported email type: ${type}` };
+    }
+
+    return { success: true, channel: 'email' };
+  } catch (err: any) {
+    return { success: false, channel: 'email', error: err.message ?? String(err) };
+  }
+}

--- a/common/compiled/node/comms/service/types.ts
+++ b/common/compiled/node/comms/service/types.ts
@@ -1,18 +1,343 @@
 // Unified comms service — shared types
 
+import type { SendEmailOpts, SgAttachment } from '../sendgrid/types.ts';
+import type { ContactData, TelegramMessageOpts, VenueData } from '../telegram2/types.ts';
 import type { CommsChannel } from '../tenant/types.ts';
+import type {
+  WaAddressRequestOpts,
+  WaButtonsOpts,
+  WaContact,
+  WaCtaUrlOpts,
+  WaDocumentOpts,
+  WaFlowOpts,
+  WaListOpts,
+  WaLocation,
+  WaMediaInput,
+  WaMediaOpts,
+  WaMessageOpts,
+  WaTemplateOpts,
+  WaTextOpts,
+} from '../whatsapp2/types.ts';
 
-// ─── Send ─────────────────────────────────────────────────────────────────────
+// ─── Telegram payload shapes ──────────────────────────────────────────────────
 
-/** Request shape for the unified send() function */
-export interface SendRequest {
-  tenantId: number;
-  configLabel?: string;
-  channel: CommsChannel;
-  to: string;
-  type: string;
-  payload: Record<string, any>;
+export interface TgTextPayload {
+  /** The message text. Supports HTML/Markdown if opts.parse_mode is set. */
+  text: string;
+  /** Telegram message options (parse_mode, reply_markup, disable_notification, etc.) */
+  opts?: TelegramMessageOpts;
 }
+
+export interface TgPhotoPayload {
+  /** Photo to send: HTTPS URL, local file path, or Telegram file_id. */
+  photo: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgVideoPayload {
+  /** Video to send: HTTPS URL, local file path, or Telegram file_id. */
+  video: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgAudioPayload {
+  /** Audio track to send: HTTPS URL, local file path, or Telegram file_id. */
+  audio: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgDocumentPayload {
+  /** Document/file to send: HTTPS URL, local file path, or Telegram file_id. */
+  document: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgVoicePayload {
+  /** OGG/OPUS voice message: HTTPS URL, local file path, or Telegram file_id. */
+  voice: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgVideoNotePayload {
+  /** Round video (1:1 aspect ratio): HTTPS URL, local file path, or Telegram file_id. */
+  video_note: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgStickerPayload {
+  /** Sticker (WEBP/TGS/WEBM): HTTPS URL, local file path, or Telegram file_id. */
+  sticker: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgAnimationPayload {
+  /** GIF or MP4 animation: HTTPS URL, local file path, or Telegram file_id. */
+  animation: string;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgLocationPayload {
+  /** Latitude coordinate. */
+  latitude: number;
+  /** Longitude coordinate. */
+  longitude: number;
+  /** Telegram message options (live_period, heading, proximity_alert_radius, etc.) */
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgVenuePayload {
+  /** Venue data: latitude, longitude, title, address, and optional place IDs. */
+  venue: VenueData;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgContactPayload {
+  /** Contact card: phone_number, first_name, last_name, vcard. */
+  contact: ContactData;
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgPollPayload {
+  /** Poll question text (1-300 characters). */
+  question: string;
+  /** Answer options (2-10 strings, each 1-100 characters). */
+  options: string[];
+  /** Poll options (type, is_anonymous, correct_option_id, explanation, etc.) */
+  opts?: TelegramMessageOpts;
+}
+
+export interface TgDicePayload {
+  /** Dice emoji. One of: 🎲 🎯 🏀 ⚽ 🎳 🎰. Default: 🎲 */
+  emoji?: string;
+  opts?: TelegramMessageOpts;
+}
+
+// ─── WhatsApp payload shapes ──────────────────────────────────────────────────
+
+export interface WaTextPayload {
+  /** The message text body. */
+  text: string;
+  /** Text options: preview_url, replyTo. */
+  opts?: WaTextOpts;
+}
+
+export interface WaImagePayload {
+  /** Media source: { id: "<media_id>" } or { link: "https://..." }. */
+  media: WaMediaInput;
+  /** Optional caption shown below the image. */
+  caption?: string;
+  /** Media options: replyTo. */
+  opts?: WaMediaOpts;
+}
+
+export interface WaAudioPayload {
+  /** Media source: { id: "<media_id>" } or { link: "https://..." }. */
+  media: WaMediaInput;
+  /** Audio options: replyTo. Note: captions are NOT supported for audio. */
+  opts?: WaMessageOpts;
+}
+
+export interface WaVideoPayload {
+  /** Media source: { id: "<media_id>" } or { link: "https://..." }. */
+  media: WaMediaInput;
+  /** Optional caption shown below the video. */
+  caption?: string;
+  /** Media options: replyTo. */
+  opts?: WaMediaOpts;
+}
+
+export interface WaStickerPayload {
+  /** Media source: { id: "<media_id>" } or { link: "https://..." }. WEBP only. */
+  media: WaMediaInput;
+  /** Sticker options: replyTo. */
+  opts?: WaMessageOpts;
+}
+
+export interface WaDocumentPayload {
+  /** Media source: { id: "<media_id>" } or { link: "https://..." }. */
+  media: WaMediaInput;
+  /** Optional caption shown below the document preview. */
+  caption?: string;
+  /** Display filename shown in chat (e.g. "report.pdf"). */
+  filename?: string;
+  /** Document options: replyTo. */
+  opts?: WaDocumentOpts;
+}
+
+export interface WaLocationPayload {
+  /** Location data: latitude, longitude, name, address. */
+  location: WaLocation;
+  /** Location options: replyTo. */
+  opts?: WaMessageOpts;
+}
+
+export interface WaContactsPayload {
+  /** Array of contact cards (vCard-style). */
+  contacts: WaContact[];
+  /** Contacts options: replyTo. */
+  opts?: WaMessageOpts;
+}
+
+/**
+ * For interactive/template types the payload IS the options object.
+ * Re-exported from whatsapp2/types.ts to avoid duplication.
+ */
+export type WaTemplatePayload = WaTemplateOpts;
+export type WaButtonsPayload = WaButtonsOpts;
+export type WaListPayload = WaListOpts;
+export type WaCtaUrlPayload = WaCtaUrlOpts;
+export type WaAddressRequestPayload = WaAddressRequestOpts;
+export type WaFlowPayload = WaFlowOpts;
+
+// ─── Email (SendGrid) payload shapes ──────────────────────────────────────────
+
+export interface EmailHtmlPayload {
+  /** Email subject line. */
+  subject: string;
+  /** Full HTML body content. */
+  html: string;
+  /** SendGrid send options: cc, bcc, replyTo, categories, trackingSettings, etc. */
+  opts?: SendEmailOpts;
+}
+
+export interface EmailDynamicPayload {
+  /** SendGrid dynamic template ID (starts with "d-"). */
+  templateId: string;
+  /** Handlebars variables to substitute in the template. */
+  dynamicData: Record<string, unknown>;
+  /** SendGrid send options: cc, bcc, replyTo, categories, trackingSettings, etc. */
+  opts?: SendEmailOpts;
+}
+
+export interface EmailHtmlAttachmentsPayload {
+  /** Email subject line. */
+  subject: string;
+  /** Full HTML body content. */
+  html: string;
+  /** File attachments (base64-encoded content, filename, MIME type). */
+  attachments: SgAttachment[];
+  /** SendGrid send options: cc, bcc, replyTo, categories, trackingSettings, etc. */
+  opts?: SendEmailOpts;
+}
+
+export interface EmailScheduledPayload {
+  /** Email subject line. */
+  subject: string;
+  /** Full HTML body content. */
+  html: string;
+  /** Unix timestamp (seconds) — schedule delivery up to 72 hours in the future. */
+  sendAt: number;
+  /** SendGrid send options: cc, bcc, replyTo, categories, trackingSettings, etc. */
+  opts?: SendEmailOpts;
+}
+
+export interface EmailScheduledDynamicPayload {
+  /** SendGrid dynamic template ID (starts with "d-"). */
+  templateId: string;
+  /** Handlebars variables to substitute in the template. */
+  dynamicData: Record<string, unknown>;
+  /** Unix timestamp (seconds) — schedule delivery up to 72 hours in the future. */
+  sendAt: number;
+  /** SendGrid send options: cc, bcc, replyTo, categories, trackingSettings, etc. */
+  opts?: SendEmailOpts;
+}
+
+// ─── Message type string literal unions ──────────────────────────────────────
+
+export type TelegramMessageType =
+  | 'text'
+  | 'photo'
+  | 'video'
+  | 'audio'
+  | 'document'
+  | 'voice'
+  | 'video_note'
+  | 'sticker'
+  | 'animation'
+  | 'location'
+  | 'venue'
+  | 'contact'
+  | 'poll'
+  | 'dice';
+
+export type WhatsAppMessageType =
+  | 'text'
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'sticker'
+  | 'document'
+  | 'location'
+  | 'contacts'
+  | 'template'
+  | 'buttons'
+  | 'list'
+  | 'cta_url'
+  | 'address_request'
+  | 'flow';
+
+export type EmailMessageType = 'html' | 'dynamic' | 'html_attachments' | 'scheduled' | 'scheduled_dynamic';
+
+// ─── Channel-specific discriminated union request types ───────────────────────
+
+type TelegramBase = { tenantId: number; configLabel?: string; channel: 'telegram'; to: string };
+
+export type TelegramSendRequest = TelegramBase &
+  (
+    | { type: 'text'; payload: TgTextPayload }
+    | { type: 'photo'; payload: TgPhotoPayload }
+    | { type: 'video'; payload: TgVideoPayload }
+    | { type: 'audio'; payload: TgAudioPayload }
+    | { type: 'document'; payload: TgDocumentPayload }
+    | { type: 'voice'; payload: TgVoicePayload }
+    | { type: 'video_note'; payload: TgVideoNotePayload }
+    | { type: 'sticker'; payload: TgStickerPayload }
+    | { type: 'animation'; payload: TgAnimationPayload }
+    | { type: 'location'; payload: TgLocationPayload }
+    | { type: 'venue'; payload: TgVenuePayload }
+    | { type: 'contact'; payload: TgContactPayload }
+    | { type: 'poll'; payload: TgPollPayload }
+    | { type: 'dice'; payload: TgDicePayload }
+  );
+
+type WhatsAppBase = { tenantId: number; configLabel?: string; channel: 'whatsapp'; to: string };
+
+export type WhatsAppSendRequest = WhatsAppBase &
+  (
+    | { type: 'text'; payload: WaTextPayload }
+    | { type: 'image'; payload: WaImagePayload }
+    | { type: 'audio'; payload: WaAudioPayload }
+    | { type: 'video'; payload: WaVideoPayload }
+    | { type: 'sticker'; payload: WaStickerPayload }
+    | { type: 'document'; payload: WaDocumentPayload }
+    | { type: 'location'; payload: WaLocationPayload }
+    | { type: 'contacts'; payload: WaContactsPayload }
+    | { type: 'template'; payload: WaTemplatePayload }
+    | { type: 'buttons'; payload: WaButtonsPayload }
+    | { type: 'list'; payload: WaListPayload }
+    | { type: 'cta_url'; payload: WaCtaUrlPayload }
+    | { type: 'address_request'; payload: WaAddressRequestPayload }
+    | { type: 'flow'; payload: WaFlowPayload }
+  );
+
+type EmailBase = { tenantId: number; configLabel?: string; channel: 'email'; to: string };
+
+export type EmailSendRequest = EmailBase &
+  (
+    | { type: 'html'; payload: EmailHtmlPayload }
+    | { type: 'dynamic'; payload: EmailDynamicPayload }
+    | { type: 'html_attachments'; payload: EmailHtmlAttachmentsPayload }
+    | { type: 'scheduled'; payload: EmailScheduledPayload }
+    | { type: 'scheduled_dynamic'; payload: EmailScheduledDynamicPayload }
+  );
+
+// ─── Combined SendRequest ─────────────────────────────────────────────────────
+
+/**
+ * Typed send request — discriminated union across all channels and message types.
+ * TypeScript narrows the `payload` type based on `channel` + `type`.
+ */
+export type SendRequest = TelegramSendRequest | WhatsAppSendRequest | EmailSendRequest;
 
 /** Normalized result from any channel send */
 export interface SendResult {
@@ -24,16 +349,11 @@ export interface SendResult {
 
 // ─── Broadcast ────────────────────────────────────────────────────────────────
 
-/** Request shape for broadcast() */
-export interface BroadcastRequest {
-  tenantId: number;
-  configLabel?: string;
-  channel: CommsChannel;
-  recipients: string[];
-  type: string;
-  payload: Record<string, any>;
-  options?: BroadcastOptions;
-}
+/** Request shape for broadcast() — same channel/type/payload discrimination as SendRequest. */
+export type BroadcastRequest =
+  | (Omit<TelegramSendRequest, 'to'> & { recipients: string[]; options?: BroadcastOptions })
+  | (Omit<WhatsAppSendRequest, 'to'> & { recipients: string[]; options?: BroadcastOptions })
+  | (Omit<EmailSendRequest, 'to'> & { recipients: string[]; options?: BroadcastOptions });
 
 export interface BroadcastOptions {
   /** Sequential sends one-by-one with optional delay. Concurrent sends in batches. Default: 'sequential'. */

--- a/common/compiled/node/comms/service/types.ts
+++ b/common/compiled/node/comms/service/types.ts
@@ -1,0 +1,62 @@
+// Unified comms service — shared types
+
+import type { CommsChannel } from '../tenant/types.ts';
+
+// ─── Send ─────────────────────────────────────────────────────────────────────
+
+/** Request shape for the unified send() function */
+export interface SendRequest {
+  tenantId: number;
+  configLabel?: string;
+  channel: CommsChannel;
+  to: string;
+  type: string;
+  payload: Record<string, any>;
+}
+
+/** Normalized result from any channel send */
+export interface SendResult {
+  success: boolean;
+  channel: CommsChannel;
+  messageId?: string;
+  error?: string;
+}
+
+// ─── Broadcast ────────────────────────────────────────────────────────────────
+
+/** Request shape for broadcast() */
+export interface BroadcastRequest {
+  tenantId: number;
+  configLabel?: string;
+  channel: CommsChannel;
+  recipients: string[];
+  type: string;
+  payload: Record<string, any>;
+  options?: BroadcastOptions;
+}
+
+export interface BroadcastOptions {
+  /** Sequential sends one-by-one with optional delay. Concurrent sends in batches. Default: 'sequential'. */
+  mode?: 'sequential' | 'concurrent';
+  /** Delay in ms between sends in sequential mode. Default: 0. */
+  delayMs?: number;
+  /** Max parallel sends in concurrent mode. Default: 5. */
+  concurrency?: number;
+}
+
+/** Result from broadcast — per-recipient status */
+export interface BroadcastResult {
+  success: boolean;
+  channel: CommsChannel;
+  total: number;
+  sent: number;
+  failed: number;
+  results: BroadcastRecipientResult[];
+}
+
+export interface BroadcastRecipientResult {
+  to: string;
+  success: boolean;
+  messageId?: string;
+  error?: string;
+}

--- a/common/compiled/node/comms/telegram2/inbound.ts
+++ b/common/compiled/node/comms/telegram2/inbound.ts
@@ -1,4 +1,5 @@
-import type { TgMessage, TgUpdate } from './types.ts';
+import { apiRequest } from './outbound.ts';
+import type { SetWebhookOpts, TgMessage, TgUpdate } from './types.ts';
 
 // ─── Extractors ───────────────────────────────────────────────────────────────
 
@@ -263,3 +264,54 @@ export const handleUpdate = (update: TgUpdate) => {
 
   return { updateType: 'unknown', data: update };
 };
+
+// ─── Webhook Management ───────────────────────────────────────────────────────
+
+/**
+ * Register a webhook URL for a Telegram bot.
+ * Telegram will send updates to this URL as POST requests.
+ *
+ * @param botToken - The bot's API token
+ * @param url - HTTPS URL to send updates to (must be valid, publicly accessible)
+ * @param secretToken - Secret token for X-Telegram-Bot-Api-Secret-Token header verification (1-256 chars, A-Za-z0-9_-)
+ * @param opts - Additional webhook configuration options
+ * @returns true if webhook was set successfully
+ */
+export async function setWebhook(
+  botToken: string,
+  url: string,
+  secretToken: string,
+  opts: SetWebhookOpts = {},
+): Promise<boolean> {
+  const params: Record<string, unknown> = {
+    url,
+    secret_token: secretToken,
+    max_connections: opts.maxConnections ?? 40,
+  };
+  if (opts.allowedUpdates) params.allowed_updates = opts.allowedUpdates;
+  if (opts.ipAddress) params.ip_address = opts.ipAddress;
+  if (opts.dropPendingUpdates) params.drop_pending_updates = true;
+
+  await apiRequest(botToken, 'setWebhook', params);
+  return true;
+}
+
+/**
+ * Remove the current webhook integration for a bot.
+ *
+ * @param botToken - The bot's API token
+ * @param dropPendingUpdates - Pass true to drop all pending updates
+ * @returns true if webhook was deleted successfully
+ */
+export async function deleteWebhook(botToken: string, dropPendingUpdates = false): Promise<boolean> {
+  await apiRequest(botToken, 'deleteWebhook', { drop_pending_updates: dropPendingUpdates });
+  return true;
+}
+
+/**
+ * Get current webhook status for a bot.
+ * Useful for debugging and displaying webhook info in the UI.
+ */
+export async function getWebhookInfo(botToken: string): Promise<Record<string, unknown>> {
+  return apiRequest(botToken, 'getWebhookInfo') as Promise<Record<string, unknown>>;
+}

--- a/common/compiled/node/comms/telegram2/outbound.ts
+++ b/common/compiled/node/comms/telegram2/outbound.ts
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { sleep } from '@common/iso/sleep';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 
@@ -9,7 +10,7 @@ const BASE_URL = (token: string) => `https://api.telegram.org/bot${token}`;
 
 // ─── Core Request Helper ──────────────────────────────────────────────────────
 
-async function apiRequest(
+export async function apiRequest(
   token: string,
   method: string,
   params: Record<string, unknown> = {},
@@ -113,7 +114,6 @@ export function forceReply(input_field_placeholder = '', selective = false) {
 import type {
   ContactData,
   MediaGroupItem,
-  SetWebhookOpts,
   TelegramMessageOpts,
   TgBroadcastOpts,
   TgBroadcastResult,
@@ -671,64 +671,9 @@ export async function unpinMessage(token: string, chatId: number | string, messa
   return apiRequest(token, 'unpinChatMessage', { chat_id: chatId, message_id: messageId });
 }
 
-// ─── Webhook Management ───────────────────────────────────────────────────────
-
-/**
- * Register a webhook URL for a Telegram bot.
- * Telegram will send updates to this URL as POST requests.
- *
- * @param botToken - The bot's API token
- * @param url - HTTPS URL to send updates to (must be valid, publicly accessible)
- * @param secretToken - Secret token for X-Telegram-Bot-Api-Secret-Token header verification (1-256 chars, A-Za-z0-9_-)
- * @param opts - Additional webhook configuration options
- * @returns true if webhook was set successfully
- */
-export async function setWebhook(
-  botToken: string,
-  url: string,
-  secretToken: string,
-  opts: SetWebhookOpts = {},
-): Promise<boolean> {
-  const params: Record<string, unknown> = {
-    url,
-    secret_token: secretToken,
-    max_connections: opts.maxConnections ?? 40,
-  };
-  if (opts.allowedUpdates) params.allowed_updates = opts.allowedUpdates;
-  if (opts.ipAddress) params.ip_address = opts.ipAddress;
-  if (opts.dropPendingUpdates) params.drop_pending_updates = true;
-
-  await apiRequest(botToken, 'setWebhook', params);
-  return true;
-}
-
-/**
- * Remove the current webhook integration for a bot.
- *
- * @param botToken - The bot's API token
- * @param dropPendingUpdates - Pass true to drop all pending updates
- * @returns true if webhook was deleted successfully
- */
-export async function deleteWebhook(botToken: string, dropPendingUpdates = false): Promise<boolean> {
-  await apiRequest(botToken, 'deleteWebhook', { drop_pending_updates: dropPendingUpdates });
-  return true;
-}
-
-/**
- * Get current webhook status for a bot.
- * Useful for debugging and displaying webhook info in the UI.
- */
-export async function getWebhookInfo(botToken: string): Promise<Record<string, unknown>> {
-  return apiRequest(botToken, 'getWebhookInfo') as Promise<Record<string, unknown>>;
-}
-
 // ─── Broadcast ────────────────────────────────────────────────────────────────
 
 const TG_DEFAULT_DELAY_MS = 35; // ~28 msgs/sec — within Telegram's ~30/sec limit to different chats
-
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 /**
  * Send a message to multiple chat IDs sequentially with rate limiting.
@@ -788,7 +733,7 @@ export async function broadcast(
       }
       // Delay between sends (skip after last)
       if (i < chatIds.length - 1 && delayMs > 0) {
-        await delay(delayMs);
+        await sleep(delayMs);
       }
     }
   } else {
@@ -819,7 +764,7 @@ export async function broadcast(
 
       // Delay between batches (skip after last)
       if (i + concurrency < chatIds.length && delayMs > 0) {
-        await delay(delayMs);
+        await sleep(delayMs);
       }
     }
   }

--- a/common/compiled/node/comms/telegram2/outbound.ts
+++ b/common/compiled/node/comms/telegram2/outbound.ts
@@ -110,7 +110,16 @@ export function forceReply(input_field_placeholder = '', selective = false) {
   return JSON.stringify({ force_reply: true, input_field_placeholder, selective });
 }
 
-import type { ContactData, MediaGroupItem, SetWebhookOpts, TelegramMessageOpts, VenueData } from './types.ts';
+import type {
+  ContactData,
+  MediaGroupItem,
+  SetWebhookOpts,
+  TelegramMessageOpts,
+  TgBroadcastOpts,
+  TgBroadcastResult,
+  TgBroadcastResultItem,
+  VenueData,
+} from './types.ts';
 
 // ─── Shared Message Options ───────────────────────────────────────────────────
 
@@ -711,4 +720,115 @@ export async function deleteWebhook(botToken: string, dropPendingUpdates = false
  */
 export async function getWebhookInfo(botToken: string): Promise<Record<string, unknown>> {
   return apiRequest(botToken, 'getWebhookInfo') as Promise<Record<string, unknown>>;
+}
+
+// ─── Broadcast ────────────────────────────────────────────────────────────────
+
+const TG_DEFAULT_DELAY_MS = 35; // ~28 msgs/sec — within Telegram's ~30/sec limit to different chats
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Send a message to multiple chat IDs sequentially with rate limiting.
+ *
+ * Uses a callback pattern — pass any existing send function as the sender.
+ * The broadcast function handles looping, rate limiting, and result aggregation.
+ *
+ * @param chatIds - Array of Telegram chat IDs (user, group, or channel)
+ * @param sendFn - A function that sends to a single chat. Receives `chatId` and should return the API response.
+ * @param opts - Broadcast options (delay between sends, concurrency)
+ * @returns Aggregated results with per-recipient success/failure details
+ *
+ * @example
+ * // Text broadcast
+ * await broadcast(
+ *   [123456789, 987654321, -100123456789],
+ *   (chatId) => sendMessage(token, chatId, 'Hello everyone!'),
+ * )
+ *
+ * @example
+ * // Photo broadcast with caption
+ * await broadcast(
+ *   chatIds,
+ *   (chatId) => sendPhoto(token, chatId, 'https://example.com/promo.jpg', { caption: 'Check this out!' }),
+ *   { delayMs: 50 },
+ * )
+ *
+ * @example
+ * // Document broadcast
+ * await broadcast(
+ *   chatIds,
+ *   (chatId) => sendDocument(token, chatId, 'https://example.com/report.pdf', { caption: 'Monthly report' }),
+ * )
+ */
+export async function broadcast(
+  chatIds: (string | number)[],
+  sendFn: (chatId: string | number) => Promise<unknown>,
+  opts?: TgBroadcastOpts,
+): Promise<TgBroadcastResult> {
+  const delayMs = opts?.delayMs ?? TG_DEFAULT_DELAY_MS;
+  const concurrency = opts?.concurrency ?? 1;
+  const results: TgBroadcastResultItem[] = [];
+
+  if (concurrency <= 1) {
+    // Sequential mode (default — safest for rate limits)
+    for (let i = 0; i < chatIds.length; i++) {
+      const chatId = chatIds[i];
+      try {
+        const data = await sendFn(chatId);
+        results.push({ chatId, success: true, data });
+      } catch (err: unknown) {
+        const error =
+          err instanceof TelegramError
+            ? { message: err.message, code: err.code, method: err.method }
+            : { message: err instanceof Error ? err.message : String(err) };
+        results.push({ chatId, success: false, error });
+      }
+      // Delay between sends (skip after last)
+      if (i < chatIds.length - 1 && delayMs > 0) {
+        await delay(delayMs);
+      }
+    }
+  } else {
+    // Concurrent mode — process in batches
+    for (let i = 0; i < chatIds.length; i += concurrency) {
+      const batch = chatIds.slice(i, i + concurrency);
+      const batchResults = await Promise.allSettled(
+        batch.map(async chatId => {
+          const data = await sendFn(chatId);
+          return { chatId, data };
+        }),
+      );
+
+      for (let j = 0; j < batchResults.length; j++) {
+        const result = batchResults[j];
+        const chatId = batch[j];
+        if (result.status === 'fulfilled') {
+          results.push({ chatId, success: true, data: result.value.data });
+        } else {
+          const err = result.reason;
+          const error =
+            err instanceof TelegramError
+              ? { message: err.message, code: err.code, method: err.method }
+              : { message: err instanceof Error ? err.message : String(err) };
+          results.push({ chatId, success: false, error });
+        }
+      }
+
+      // Delay between batches (skip after last)
+      if (i + concurrency < chatIds.length && delayMs > 0) {
+        await delay(delayMs);
+      }
+    }
+  }
+
+  const sent = results.filter(r => r.success).length;
+  return {
+    total: chatIds.length,
+    sent,
+    failed: chatIds.length - sent,
+    results,
+  };
 }

--- a/common/compiled/node/comms/telegram2/outbound.ts
+++ b/common/compiled/node/comms/telegram2/outbound.ts
@@ -110,7 +110,7 @@ export function forceReply(input_field_placeholder = '', selective = false) {
   return JSON.stringify({ force_reply: true, input_field_placeholder, selective });
 }
 
-import type { ContactData, MediaGroupItem, TelegramMessageOpts, VenueData } from './types.ts';
+import type { ContactData, MediaGroupItem, SetWebhookOpts, TelegramMessageOpts, VenueData } from './types.ts';
 
 // ─── Shared Message Options ───────────────────────────────────────────────────
 
@@ -660,4 +660,55 @@ export async function pinMessage(
 
 export async function unpinMessage(token: string, chatId: number | string, messageId: number) {
   return apiRequest(token, 'unpinChatMessage', { chat_id: chatId, message_id: messageId });
+}
+
+// ─── Webhook Management ───────────────────────────────────────────────────────
+
+/**
+ * Register a webhook URL for a Telegram bot.
+ * Telegram will send updates to this URL as POST requests.
+ *
+ * @param botToken - The bot's API token
+ * @param url - HTTPS URL to send updates to (must be valid, publicly accessible)
+ * @param secretToken - Secret token for X-Telegram-Bot-Api-Secret-Token header verification (1-256 chars, A-Za-z0-9_-)
+ * @param opts - Additional webhook configuration options
+ * @returns true if webhook was set successfully
+ */
+export async function setWebhook(
+  botToken: string,
+  url: string,
+  secretToken: string,
+  opts: SetWebhookOpts = {},
+): Promise<boolean> {
+  const params: Record<string, unknown> = {
+    url,
+    secret_token: secretToken,
+    max_connections: opts.maxConnections ?? 40,
+  };
+  if (opts.allowedUpdates) params.allowed_updates = opts.allowedUpdates;
+  if (opts.ipAddress) params.ip_address = opts.ipAddress;
+  if (opts.dropPendingUpdates) params.drop_pending_updates = true;
+
+  await apiRequest(botToken, 'setWebhook', params);
+  return true;
+}
+
+/**
+ * Remove the current webhook integration for a bot.
+ *
+ * @param botToken - The bot's API token
+ * @param dropPendingUpdates - Pass true to drop all pending updates
+ * @returns true if webhook was deleted successfully
+ */
+export async function deleteWebhook(botToken: string, dropPendingUpdates = false): Promise<boolean> {
+  await apiRequest(botToken, 'deleteWebhook', { drop_pending_updates: dropPendingUpdates });
+  return true;
+}
+
+/**
+ * Get current webhook status for a bot.
+ * Useful for debugging and displaying webhook info in the UI.
+ */
+export async function getWebhookInfo(botToken: string): Promise<Record<string, unknown>> {
+  return apiRequest(botToken, 'getWebhookInfo') as Promise<Record<string, unknown>>;
 }

--- a/common/compiled/node/comms/telegram2/types.ts
+++ b/common/compiled/node/comms/telegram2/types.ts
@@ -181,6 +181,21 @@ export interface ContactData {
   vcard?: string;
 }
 
+// ─── Webhook management types ─────────────────────────────────────────────────
+
+export interface SetWebhookOpts {
+  /** Maximum allowed number of simultaneous HTTPS connections to the webhook (1-100, default 40) */
+  maxConnections?: number;
+  /** List of update types to receive. Omit to receive all. */
+  allowedUpdates?: string[];
+  /** Upload your public key certificate for self-signed webhooks */
+  certificate?: string;
+  /** A fixed IP address to send webhook requests to instead of resolving via DNS */
+  ipAddress?: string;
+  /** Pass True to drop all pending updates */
+  dropPendingUpdates?: boolean;
+}
+
 // // TODO: Need to be defined
 // data shape (updateType === message):
 // {

--- a/common/compiled/node/comms/telegram2/types.ts
+++ b/common/compiled/node/comms/telegram2/types.ts
@@ -196,6 +196,29 @@ export interface SetWebhookOpts {
   dropPendingUpdates?: boolean;
 }
 
+// ─── Broadcast types ──────────────────────────────────────────────────────────
+
+export interface TgBroadcastOpts {
+  /** Delay in milliseconds between each send. Default: 35 (≈28 msgs/sec, within Telegram's ~30/sec limit). */
+  delayMs?: number;
+  /** Maximum number of concurrent sends. Default: 1 (sequential). */
+  concurrency?: number;
+}
+
+export interface TgBroadcastResultItem {
+  chatId: string | number;
+  success: boolean;
+  data?: unknown;
+  error?: { message: string; code?: number; method?: string };
+}
+
+export interface TgBroadcastResult {
+  total: number;
+  sent: number;
+  failed: number;
+  results: TgBroadcastResultItem[];
+}
+
 // // TODO: Need to be defined
 // data shape (updateType === message):
 // {

--- a/common/compiled/node/comms/tenant/crypto.ts
+++ b/common/compiled/node/comms/tenant/crypto.ts
@@ -1,0 +1,40 @@
+// Multi-tenant communications — credential encryption/decryption
+
+import { decryptText, encryptText, genIv, genKey } from '../../utils/aes.ts';
+
+const ALG = 'aes-256-cbc';
+
+function getPassword(): string {
+  const password = process.env.COMMS_ENCRYPTION_KEY;
+  if (!password) throw new Error('COMMS_ENCRYPTION_KEY environment variable is not set');
+  return password;
+}
+
+/**
+ * Encrypt a credentials object for storage in DB.
+ * Returns a string in format: base64(iv):base64(ciphertext)
+ */
+export function encryptCredentials(credentials: Record<string, string>): string {
+  const password = getPassword();
+  const key = genKey(ALG, password);
+  const iv = genIv();
+  const plaintext = JSON.stringify(credentials);
+  const ciphertext = encryptText(ALG, key, iv, plaintext);
+  const ivBase64 = iv.toString('base64');
+  return `${ivBase64}:${ciphertext}`;
+}
+
+/**
+ * Decrypt a credentials string from DB back to an object.
+ * Expects format: base64(iv):base64(ciphertext)
+ */
+export function decryptCredentials(encrypted: string): Record<string, string> {
+  const password = getPassword();
+  const key = genKey(ALG, password);
+  const [ivBase64, ciphertext] = encrypted.split(':');
+  if (!ivBase64 || !ciphertext)
+    throw new Error('Invalid encrypted credentials format. Expected base64(iv):base64(ciphertext)');
+  const iv = Buffer.from(ivBase64, 'base64');
+  const plaintext = decryptText(ALG, key, iv, ciphertext);
+  return JSON.parse(plaintext);
+}

--- a/common/compiled/node/comms/tenant/crypto.ts
+++ b/common/compiled/node/comms/tenant/crypto.ts
@@ -1,8 +1,6 @@
 // Multi-tenant communications — credential encryption/decryption
 
-import { decryptText, encryptText, genIv, genKey } from '../../utils/aes.ts';
-
-const ALG = 'aes-256-cbc';
+import { decryptWithPassword, encryptWithPassword } from '../../utils/aes.ts';
 
 function getPassword(): string {
   const password = process.env.COMMS_ENCRYPTION_KEY;
@@ -15,13 +13,7 @@ function getPassword(): string {
  * Returns a string in format: base64(iv):base64(ciphertext)
  */
 export function encryptCredentials(credentials: Record<string, string>): string {
-  const password = getPassword();
-  const key = genKey(ALG, password);
-  const iv = genIv();
-  const plaintext = JSON.stringify(credentials);
-  const ciphertext = encryptText(ALG, key, iv, plaintext);
-  const ivBase64 = iv.toString('base64');
-  return `${ivBase64}:${ciphertext}`;
+  return encryptWithPassword(JSON.stringify(credentials), getPassword());
 }
 
 /**
@@ -29,12 +21,5 @@ export function encryptCredentials(credentials: Record<string, string>): string 
  * Expects format: base64(iv):base64(ciphertext)
  */
 export function decryptCredentials(encrypted: string): Record<string, string> {
-  const password = getPassword();
-  const key = genKey(ALG, password);
-  const [ivBase64, ciphertext] = encrypted.split(':');
-  if (!ivBase64 || !ciphertext)
-    throw new Error('Invalid encrypted credentials format. Expected base64(iv):base64(ciphertext)');
-  const iv = Buffer.from(ivBase64, 'base64');
-  const plaintext = decryptText(ALG, key, iv, ciphertext);
-  return JSON.parse(plaintext);
+  return JSON.parse(decryptWithPassword(encrypted, getPassword()));
 }

--- a/common/compiled/node/comms/tenant/resolver.ts
+++ b/common/compiled/node/comms/tenant/resolver.ts
@@ -1,0 +1,72 @@
+// Multi-tenant communications — credential resolver
+// Uses configure/setup injection pattern (same as auth/rbac.ts)
+
+import { and, eq } from 'drizzle-orm';
+import { decryptCredentials } from './crypto.ts';
+import type { CommsChannel, CommsProvider, TenantCommsConfig } from './types.ts';
+
+// ─── Module-scoped injected dependencies ──────────────────────────────────────
+
+// biome-ignore lint/suspicious/noExplicitAny: configurable table reference injected by the app
+let _tenantCommsConfig: any = null;
+let _serviceName = 'drizzle1';
+// biome-ignore lint/suspicious/noExplicitAny: service lookup function injected by the app
+let _lookup: ((name: string) => any) | null = null;
+
+const db = () => _lookup?.(_serviceName);
+
+/** Register the tenantCommsConfig Drizzle table. Call once at app startup. */
+export const configure = (tables: { tenantCommsConfig: unknown }) => {
+  _tenantCommsConfig = tables.tenantCommsConfig;
+};
+
+/** Register the DB service lookup. Call once at app startup. */
+export const setup = (serviceName: string, lookup: (name: string) => unknown) => {
+  _serviceName = serviceName;
+  _lookup = lookup as (name: string) => any;
+};
+
+/** Check if both configure() and setup() have been called. */
+export const isConfigured = () => _tenantCommsConfig !== null && _lookup !== null;
+
+/**
+ * Resolve communication credentials for a tenant + channel.
+ *
+ * @param tenantId - The tenant's ID (from req.user.tenant_id)
+ * @param channel - The communication channel ('telegram', 'email', 'whatsapp', 'sms')
+ * @returns Decrypted tenant comms config
+ * @throws Error if not configured or no active config found
+ */
+export async function resolveCommsCredentials(tenantId: number, channel: CommsChannel): Promise<TenantCommsConfig> {
+  if (!isConfigured()) {
+    throw new Error('Comms tenant module is not configured. Call configure() and setup() at app startup.');
+  }
+
+  const [config] = await db()
+    .select()
+    .from(_tenantCommsConfig)
+    .where(
+      and(
+        eq(_tenantCommsConfig.tenant_id, tenantId),
+        eq(_tenantCommsConfig.channel, channel),
+        eq(_tenantCommsConfig.is_active, true),
+      ),
+    )
+    .limit(1);
+
+  if (!config) {
+    throw new Error(
+      `No active ${channel} configuration found for tenant ${tenantId}. Each tenant must configure their own communication credentials.`,
+    );
+  }
+
+  return {
+    id: config.id,
+    tenantId: config.tenant_id,
+    channel: config.channel as CommsChannel,
+    provider: config.provider as CommsProvider,
+    credentials: decryptCredentials(config.credentials),
+    senderIdentity: config.sender_identity as Record<string, string>,
+    isActive: config.is_active,
+  };
+}

--- a/common/compiled/node/comms/tenant/resolver.ts
+++ b/common/compiled/node/comms/tenant/resolver.ts
@@ -34,39 +34,91 @@ export const isConfigured = () => _tenantCommsConfig !== null && _lookup !== nul
  *
  * @param tenantId - The tenant's ID (from req.user.tenant_id)
  * @param channel - The communication channel ('telegram', 'email', 'whatsapp', 'sms')
+ * @param label - Optional label to select a specific config (e.g., 'Support WA', 'Marketing WA'). If omitted, returns the first active config for the channel.
  * @returns Decrypted tenant comms config
  * @throws Error if not configured or no active config found
  */
-export async function resolveCommsCredentials(tenantId: number, channel: CommsChannel): Promise<TenantCommsConfig> {
+export async function resolveCommsCredentials(
+  tenantId: number,
+  channel: CommsChannel,
+  label?: string,
+): Promise<TenantCommsConfig> {
   if (!isConfigured()) {
     throw new Error('Comms tenant module is not configured. Call configure() and setup() at app startup.');
+  }
+
+  const conditions = [
+    eq(_tenantCommsConfig.tenant_id, tenantId),
+    eq(_tenantCommsConfig.channel, channel),
+    eq(_tenantCommsConfig.is_active, true),
+  ];
+  if (label) {
+    conditions.push(eq(_tenantCommsConfig.label, label));
   }
 
   const [config] = await db()
     .select()
     .from(_tenantCommsConfig)
-    .where(
-      and(
-        eq(_tenantCommsConfig.tenant_id, tenantId),
-        eq(_tenantCommsConfig.channel, channel),
-        eq(_tenantCommsConfig.is_active, true),
-      ),
-    )
+    .where(and(...conditions))
     .limit(1);
 
   if (!config) {
+    const labelMsg = label ? ` with label "${label}"` : '';
     throw new Error(
-      `No active ${channel} configuration found for tenant ${tenantId}. Each tenant must configure their own communication credentials.`,
+      `No active ${channel} configuration${labelMsg} found for tenant ${tenantId}. Each tenant must configure their own communication credentials.`,
     );
   }
 
   return {
     id: config.id,
     tenantId: config.tenant_id,
+    label: config.label,
     channel: config.channel as CommsChannel,
     provider: config.provider as CommsProvider,
     credentials: decryptCredentials(config.credentials),
     senderIdentity: config.sender_identity as Record<string, string>,
     isActive: config.is_active,
   };
+}
+
+/**
+ * List all active configs for a tenant + channel.
+ * Useful for populating a dropdown selector in the UI.
+ * Returns configs WITHOUT decrypted credentials (only id, label, senderIdentity).
+ */
+export async function listCommsConfigs(
+  tenantId: number,
+  channel?: CommsChannel,
+): Promise<
+  Array<{
+    id: number;
+    label: string;
+    channel: CommsChannel;
+    provider: CommsProvider;
+    senderIdentity: Record<string, string>;
+    isActive: boolean;
+  }>
+> {
+  if (!isConfigured()) {
+    throw new Error('Comms tenant module is not configured. Call configure() and setup() at app startup.');
+  }
+
+  const conditions = [eq(_tenantCommsConfig.tenant_id, tenantId), eq(_tenantCommsConfig.is_active, true)];
+  if (channel) {
+    conditions.push(eq(_tenantCommsConfig.channel, channel));
+  }
+
+  const configs = await db()
+    .select()
+    .from(_tenantCommsConfig)
+    .where(and(...conditions));
+
+  return configs.map((c: any) => ({
+    id: c.id,
+    label: c.label,
+    channel: c.channel as CommsChannel,
+    provider: c.provider as CommsProvider,
+    senderIdentity: c.sender_identity as Record<string, string>,
+    isActive: c.is_active,
+  }));
 }

--- a/common/compiled/node/comms/tenant/resolver.ts
+++ b/common/compiled/node/comms/tenant/resolver.ts
@@ -1,7 +1,7 @@
 // Multi-tenant communications — credential resolver
 // Uses configure/setup injection pattern (same as auth/rbac.ts)
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { decryptCredentials } from './crypto.ts';
 import type { CommsChannel, CommsProvider, TenantCommsConfig } from './types.ts';
 
@@ -121,4 +121,93 @@ export async function listCommsConfigs(
     senderIdentity: c.sender_identity as Record<string, string>,
     isActive: c.is_active,
   }));
+}
+
+// ─── Reverse-lookup resolvers (for webhook routing) ───────────────────────────
+
+/**
+ * Resolve a comms config by channel + label (across all tenants).
+ * Used by Telegram webhook handler to identify which tenant/bot a webhook belongs to.
+ *
+ * @param channel - The communication channel
+ * @param label - The config label (from the webhook URL path)
+ * @returns Decrypted tenant comms config, or null if not found
+ */
+export async function resolveCommsConfigByLabel(
+  channel: CommsChannel,
+  label: string,
+): Promise<TenantCommsConfig | null> {
+  if (!isConfigured()) {
+    throw new Error('Comms tenant module is not configured. Call configure() and setup() at app startup.');
+  }
+
+  const [config] = await db()
+    .select()
+    .from(_tenantCommsConfig)
+    .where(
+      and(
+        eq(_tenantCommsConfig.channel, channel),
+        eq(_tenantCommsConfig.label, label),
+        eq(_tenantCommsConfig.is_active, true),
+      ),
+    )
+    .limit(1);
+
+  if (!config) return null;
+
+  return {
+    id: config.id,
+    tenantId: config.tenant_id,
+    label: config.label,
+    channel: config.channel as CommsChannel,
+    provider: config.provider as CommsProvider,
+    credentials: decryptCredentials(config.credentials),
+    senderIdentity: config.sender_identity as Record<string, string>,
+    isActive: config.is_active,
+  };
+}
+
+/**
+ * Resolve a comms config by a field in the sender_identity JSONB column.
+ * Used by WhatsApp webhook handler to find config by phone_number_id,
+ * and by SendGrid inbound to find config by sender_email.
+ *
+ * @param channel - The communication channel
+ * @param identityField - The JSON key to match (e.g., 'phone_number_id', 'sender_email')
+ * @param identityValue - The value to match against
+ * @returns Decrypted tenant comms config, or null if not found
+ */
+export async function resolveCommsConfigByIdentity(
+  channel: CommsChannel,
+  identityField: string,
+  identityValue: string,
+): Promise<TenantCommsConfig | null> {
+  if (!isConfigured()) {
+    throw new Error('Comms tenant module is not configured. Call configure() and setup() at app startup.');
+  }
+
+  const [config] = await db()
+    .select()
+    .from(_tenantCommsConfig)
+    .where(
+      and(
+        eq(_tenantCommsConfig.channel, channel),
+        eq(_tenantCommsConfig.is_active, true),
+        sql`${_tenantCommsConfig.sender_identity}->>'${sql.raw(identityField)}' = ${identityValue}`,
+      ),
+    )
+    .limit(1);
+
+  if (!config) return null;
+
+  return {
+    id: config.id,
+    tenantId: config.tenant_id,
+    label: config.label,
+    channel: config.channel as CommsChannel,
+    provider: config.provider as CommsProvider,
+    credentials: decryptCredentials(config.credentials),
+    senderIdentity: config.sender_identity as Record<string, string>,
+    isActive: config.is_active,
+  };
 }

--- a/common/compiled/node/comms/tenant/types.ts
+++ b/common/compiled/node/comms/tenant/types.ts
@@ -10,6 +10,7 @@ export type CommsProvider = 'telegram' | 'sendgrid' | 'meta' | 'nexmo';
 export interface TenantCommsConfig {
   id: number;
   tenantId: number;
+  label: string;
   channel: CommsChannel;
   provider: CommsProvider;
   credentials: Record<string, string>;

--- a/common/compiled/node/comms/tenant/types.ts
+++ b/common/compiled/node/comms/tenant/types.ts
@@ -25,6 +25,8 @@ export interface TelegramCredentials {
 }
 export interface SendGridCredentials {
   api_key: string;
+  /** ECDSA public key for verifying Event Webhook signatures (X-Twilio-Email-Event-Webhook-Signature). */
+  event_webhook_public_key?: string;
 }
 export interface WhatsAppCredentials {
   token: string;

--- a/common/compiled/node/comms/tenant/types.ts
+++ b/common/compiled/node/comms/tenant/types.ts
@@ -1,0 +1,40 @@
+// Multi-tenant communications — shared types
+
+/** Supported communication channels */
+export type CommsChannel = 'telegram' | 'email' | 'whatsapp' | 'sms';
+
+/** Supported providers per channel */
+export type CommsProvider = 'telegram' | 'sendgrid' | 'meta' | 'nexmo';
+
+/** Decrypted credentials + sender identity for a tenant's channel */
+export interface TenantCommsConfig {
+  id: number;
+  tenantId: number;
+  channel: CommsChannel;
+  provider: CommsProvider;
+  credentials: Record<string, string>;
+  senderIdentity: Record<string, string>;
+  isActive: boolean;
+}
+
+export interface TelegramCredentials {
+  bot_token: string;
+}
+export interface SendGridCredentials {
+  api_key: string;
+}
+export interface WhatsAppCredentials {
+  token: string;
+}
+
+export interface TelegramSenderIdentity {
+  bot_name?: string;
+}
+export interface SendGridSenderIdentity {
+  sender_name: string;
+  sender_email: string;
+}
+export interface WhatsAppSenderIdentity {
+  phone_number_id: string;
+  business_account_id: string;
+}

--- a/common/compiled/node/comms/tenant/types.ts
+++ b/common/compiled/node/comms/tenant/types.ts
@@ -20,12 +20,16 @@ export interface TenantCommsConfig {
 
 export interface TelegramCredentials {
   bot_token: string;
+  /** Random secret token passed to Telegram's setWebhook. Verified via X-Telegram-Bot-Api-Secret-Token header. */
+  webhook_secret: string;
 }
 export interface SendGridCredentials {
   api_key: string;
 }
 export interface WhatsAppCredentials {
   token: string;
+  /** Meta App Secret — used for HMAC-SHA256 webhook signature verification (X-Hub-Signature-256). */
+  app_secret: string;
 }
 
 export interface TelegramSenderIdentity {
@@ -38,4 +42,6 @@ export interface SendGridSenderIdentity {
 export interface WhatsAppSenderIdentity {
   phone_number_id: string;
   business_account_id: string;
+  /** Token used for Meta webhook subscription verification (GET hub.verify_token handshake). */
+  verify_token?: string;
 }

--- a/common/compiled/node/comms/whatsapp2/inbound.ts
+++ b/common/compiled/node/comms/whatsapp2/inbound.ts
@@ -4,6 +4,7 @@
 // Meta's webhook payload is deeply nested and varies by event type.
 // This module normalises it into clean, typed structures.
 
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { WaDeliveryStatus, WaInboundContent, WaParsedMessage, WaParsedWebhook } from './types.ts';
 
 // ─── Main parser ──────────────────────────────────────────────────────────────
@@ -175,4 +176,26 @@ function parseContent(type: string, msg: Record<string, unknown>): WaInboundCont
     default:
       return { type };
   }
+}
+
+// ─── Webhook Signature Verification ──────────────────────────────────────────
+
+/**
+ * Verify the HMAC-SHA256 signature of an incoming Meta webhook POST.
+ *
+ * Meta signs every webhook POST with `X-Hub-Signature-256: sha256=<hex>`.
+ * Uses timing-safe comparison to prevent timing attacks.
+ *
+ * @param appSecret - The Meta App Secret from the tenant's credentials
+ * @param rawBody - The raw request body buffer (before JSON parsing)
+ * @param signatureHeader - The value of the `X-Hub-Signature-256` header
+ * @returns true if the signature is valid
+ */
+export function verifyWebhookSignature(appSecret: string, rawBody: Buffer, signatureHeader: string): boolean {
+  if (!appSecret || !signatureHeader) return false;
+  const expected = `sha256=${createHmac('sha256', appSecret).update(rawBody).digest('hex')}`;
+  const sigBuf = Buffer.from(signatureHeader);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length) return false;
+  return timingSafeEqual(sigBuf, expBuf);
 }

--- a/common/compiled/node/comms/whatsapp2/outbound.ts
+++ b/common/compiled/node/comms/whatsapp2/outbound.ts
@@ -8,6 +8,7 @@
 //   process.env.WHATSAPP_TOKEN
 //   process.env.WHATSAPP_PHONE_NUMBER_ID
 
+import { sleep } from '@common/iso/sleep';
 import type {
   WaAddressRequestOpts,
   WaBroadcastOpts,
@@ -743,10 +744,6 @@ export async function getMediaUrl(token: string, mediaId: string): Promise<strin
 
 const WA_DEFAULT_DELAY_MS = 80; // ~12 msgs/sec — safe for most tiers
 
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 /**
  * Send a message to multiple recipients sequentially with rate limiting.
  *
@@ -805,7 +802,7 @@ export async function broadcast(
       }
       // Delay between sends (skip after last)
       if (i < recipients.length - 1 && delayMs > 0) {
-        await delay(delayMs);
+        await sleep(delayMs);
       }
     }
   } else {
@@ -836,7 +833,7 @@ export async function broadcast(
 
       // Delay between batches (skip after last)
       if (i + concurrency < recipients.length && delayMs > 0) {
-        await delay(delayMs);
+        await sleep(delayMs);
       }
     }
   }

--- a/common/compiled/node/comms/whatsapp2/outbound.ts
+++ b/common/compiled/node/comms/whatsapp2/outbound.ts
@@ -10,6 +10,9 @@
 
 import type {
   WaAddressRequestOpts,
+  WaBroadcastOpts,
+  WaBroadcastResult,
+  WaBroadcastResultItem,
   WaButtonsOpts,
   WaContact,
   WaCtaUrlOpts,
@@ -735,3 +738,114 @@ export async function getMediaUrl(token: string, mediaId: string): Promise<strin
 //
 // NOT available: editLiveLocation
 //   — WhatsApp Cloud API has no live location update endpoint.
+
+// ─── Broadcast ────────────────────────────────────────────────────────────────
+
+const WA_DEFAULT_DELAY_MS = 80; // ~12 msgs/sec — safe for most tiers
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Send a message to multiple recipients sequentially with rate limiting.
+ *
+ * Uses a callback pattern — pass any existing send function as the sender.
+ * The broadcast function handles looping, rate limiting, and result aggregation.
+ *
+ * @param recipients - Array of phone numbers to send to (E.164 format without "+")
+ * @param sendFn - A function that sends to a single recipient. Receives `to` and should return the API response.
+ * @param opts - Broadcast options (delay between sends, concurrency)
+ * @returns Aggregated results with per-recipient success/failure details
+ *
+ * @example
+ * // Text broadcast
+ * await broadcast(
+ *   ['60123456789', '60198765432'],
+ *   (to) => sendText(token, phoneId, to, 'Hello!'),
+ * )
+ *
+ * @example
+ * // Template broadcast (for users outside 24h window)
+ * await broadcast(
+ *   phoneNumbers,
+ *   (to) => sendTemplate(token, phoneId, to, { name: 'hello_world', language: 'en' }),
+ *   { delayMs: 100 },
+ * )
+ *
+ * @example
+ * // Image broadcast with caption
+ * await broadcast(
+ *   phoneNumbers,
+ *   (to) => sendImage(token, phoneId, to, { link: 'https://example.com/promo.jpg' }, { caption: 'Check this out!' }),
+ * )
+ */
+export async function broadcast(
+  recipients: string[],
+  sendFn: (to: string) => Promise<unknown>,
+  opts?: WaBroadcastOpts,
+): Promise<WaBroadcastResult> {
+  const delayMs = opts?.delayMs ?? WA_DEFAULT_DELAY_MS;
+  const concurrency = opts?.concurrency ?? 1;
+  const results: WaBroadcastResultItem[] = [];
+
+  if (concurrency <= 1) {
+    // Sequential mode (default — safest for rate limits)
+    for (let i = 0; i < recipients.length; i++) {
+      const to = recipients[i];
+      try {
+        const data = await sendFn(to);
+        results.push({ to, success: true, data });
+      } catch (err: unknown) {
+        const error =
+          err instanceof WhatsAppError
+            ? { message: err.message, code: err.code, type: err.type }
+            : { message: err instanceof Error ? err.message : String(err) };
+        results.push({ to, success: false, error });
+      }
+      // Delay between sends (skip after last)
+      if (i < recipients.length - 1 && delayMs > 0) {
+        await delay(delayMs);
+      }
+    }
+  } else {
+    // Concurrent mode — process in batches
+    for (let i = 0; i < recipients.length; i += concurrency) {
+      const batch = recipients.slice(i, i + concurrency);
+      const batchResults = await Promise.allSettled(
+        batch.map(async to => {
+          const data = await sendFn(to);
+          return { to, data };
+        }),
+      );
+
+      for (let j = 0; j < batchResults.length; j++) {
+        const result = batchResults[j];
+        const to = batch[j];
+        if (result.status === 'fulfilled') {
+          results.push({ to, success: true, data: result.value.data });
+        } else {
+          const err = result.reason;
+          const error =
+            err instanceof WhatsAppError
+              ? { message: err.message, code: err.code, type: err.type }
+              : { message: err instanceof Error ? err.message : String(err) };
+          results.push({ to, success: false, error });
+        }
+      }
+
+      // Delay between batches (skip after last)
+      if (i + concurrency < recipients.length && delayMs > 0) {
+        await delay(delayMs);
+      }
+    }
+  }
+
+  const sent = results.filter(r => r.success).length;
+  return {
+    total: recipients.length,
+    sent,
+    failed: recipients.length - sent,
+    results,
+  };
+}

--- a/common/compiled/node/comms/whatsapp2/types.ts
+++ b/common/compiled/node/comms/whatsapp2/types.ts
@@ -137,6 +137,29 @@ export interface WaFlowOpts extends WaMessageOpts {
   mode?: 'published' | 'draft';
 }
 
+// ─── Broadcast ────────────────────────────────────────────────────────────────
+
+export interface WaBroadcastOpts {
+  /** Delay in milliseconds between each send. Default: 80 (≈12 msgs/sec, well within Meta's limits). */
+  delayMs?: number;
+  /** Maximum number of concurrent sends. Default: 1 (sequential). */
+  concurrency?: number;
+}
+
+export interface WaBroadcastResultItem {
+  to: string;
+  success: boolean;
+  data?: unknown;
+  error?: { message: string; code?: number; type?: string };
+}
+
+export interface WaBroadcastResult {
+  total: number;
+  sent: number;
+  failed: number;
+  results: WaBroadcastResultItem[];
+}
+
 // ─── Inbound ──────────────────────────────────────────────────────────────────
 
 export interface WaInboundText {

--- a/common/compiled/node/utils/aes.ts
+++ b/common/compiled/node/utils/aes.ts
@@ -62,3 +62,39 @@ export const genKey = (algorithm: string, password: string): Buffer => {
   hash.update(password);
   return Buffer.from(hash.digest('hex'), 'hex').subarray(0, size);
 };
+
+// ─── Higher-level password-based helpers ──────────────────────────────────────
+
+const DEFAULT_ALG = 'aes-256-cbc';
+
+/**
+ * Encrypt a plaintext string using a password.
+ * Derives a key from the password, generates a random IV, and returns the
+ * result as a `base64(iv):base64(ciphertext)` string safe for DB storage.
+ *
+ * @param text     - Plaintext to encrypt.
+ * @param password - Secret password to derive the key from.
+ * @param alg      - Cipher algorithm. Defaults to `'aes-256-cbc'`.
+ */
+export const encryptWithPassword = (text: string, password: string, alg = DEFAULT_ALG): string => {
+  const key = genKey(alg, password);
+  const iv = genIv();
+  const ciphertext = encryptText(alg, key, iv, text);
+  return `${iv.toString('base64')}:${ciphertext}`;
+};
+
+/**
+ * Decrypt a string produced by `encryptWithPassword`.
+ * Expects the format `base64(iv):base64(ciphertext)`.
+ *
+ * @param encrypted - The encrypted string from DB storage.
+ * @param password  - Secret password used during encryption.
+ * @param alg       - Cipher algorithm. Defaults to `'aes-256-cbc'`.
+ */
+export const decryptWithPassword = (encrypted: string, password: string, alg = DEFAULT_ALG): string => {
+  const [ivBase64, ciphertext] = encrypted.split(':');
+  if (!ivBase64 || !ciphertext) throw new Error('Invalid encrypted format. Expected base64(iv):base64(ciphertext)');
+  const key = genKey(alg, password);
+  const iv = Buffer.from(ivBase64, 'base64');
+  return decryptText(alg, key, iv, ciphertext);
+};

--- a/scripts/dbdeploy/db-iam/drizzle/0001_modern_shiver_man.sql
+++ b/scripts/dbdeploy/db-iam/drizzle/0001_modern_shiver_man.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "iam"."tenant_comms_config" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"tenant_id" integer NOT NULL,
+	"channel" varchar(50) NOT NULL,
+	"provider" varchar(50) NOT NULL,
+	"credentials" text NOT NULL,
+	"sender_identity" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tenant_comms_config_tenant_id_channel_provider_unique" UNIQUE("tenant_id","channel","provider")
+);
+--> statement-breakpoint
+ALTER TABLE "iam"."tenant_comms_config" ADD CONSTRAINT "tenant_comms_config_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "iam"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/scripts/dbdeploy/db-iam/drizzle/0002_strong_thanos.sql
+++ b/scripts/dbdeploy/db-iam/drizzle/0002_strong_thanos.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "iam"."tenant_comms_config" DROP CONSTRAINT "tenant_comms_config_tenant_id_channel_provider_unique";--> statement-breakpoint
+ALTER TABLE "iam"."tenant_comms_config" ADD COLUMN "label" varchar(100);--> statement-breakpoint
+UPDATE "iam"."tenant_comms_config" SET "label" = "provider" WHERE "label" IS NULL;--> statement-breakpoint
+ALTER TABLE "iam"."tenant_comms_config" ALTER COLUMN "label" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "iam"."tenant_comms_config" ADD CONSTRAINT "tenant_comms_config_tenant_id_channel_label_unique" UNIQUE("tenant_id","channel","label");

--- a/scripts/dbdeploy/db-iam/drizzle/meta/0001_snapshot.json
+++ b/scripts/dbdeploy/db-iam/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1749 @@
+{
+  "id": "3fce7e5e-3770-40dc-85ce-a63b6be4b029",
+  "prevId": "bd2d89f2-cbc9-4c78-9f30-deae2022ec70",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "iam.auth_audit_log": {
+      "name": "auth_audit_log",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_audit_user_created": {
+          "name": "idx_iam_audit_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_audit_event_created": {
+          "name": "idx_iam_audit_event_created",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_audit_created": {
+          "name": "idx_iam_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_audit_log_user_id_users_id_fk": {
+          "name": "auth_audit_log_user_id_users_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_audit_log_actor_id_users_id_fk": {
+          "name": "auth_audit_log_actor_id_users_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_audit_log_session_id_user_sessions_id_fk": {
+          "name": "auth_audit_log_session_id_user_sessions_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "user_sessions",
+          "schemaTo": "iam",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.fga_config": {
+      "name": "fga_config",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_model_id": {
+          "name": "auth_model_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "api_url": {
+          "name": "api_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http://127.0.0.1:8080'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.users": {
+      "name": "users",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_verified_at": {
+          "name": "phone_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_users_status": {
+          "name": "idx_iam_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": ["phone"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.permissions": {
+      "name": "permissions",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.role_permissions": {
+      "name": "role_permissions",
+      "schema": "iam",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_tenant_roles_id_fk": {
+          "name": "role_permissions_role_id_tenant_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "tenant_roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "schemaTo": "iam",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": ["role_id", "permission_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.roles": {
+      "name": "roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.rsa_signing_keys": {
+      "name": "rsa_signing_keys",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kid": {
+          "name": "kid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RS256'"
+        },
+        "key_use": {
+          "name": "key_use",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sig'"
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_size_bits": {
+          "name": "key_size_bits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2048
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_signing_keys_active": {
+          "name": "idx_iam_signing_keys_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rsa_signing_keys_kid_unique": {
+          "name": "rsa_signing_keys_kid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["kid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenant_comms_config": {
+      "name": "tenant_comms_config",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_identity": {
+          "name": "sender_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_comms_config_tenant_id_tenants_id_fk": {
+          "name": "tenant_comms_config_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_comms_config",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_comms_config_tenant_id_channel_provider_unique": {
+          "name": "tenant_comms_config_tenant_id_channel_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "channel", "provider"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenant_roles": {
+      "name": "tenant_roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_roles_tenant_id_tenants_id_fk": {
+          "name": "tenant_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_roles",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_roles_tenant_id_name_unique": {
+          "name": "tenant_roles_tenant_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenants": {
+      "name": "tenants",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_credentials": {
+      "name": "user_credentials",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'password'"
+        },
+        "credential_hash": {
+          "name": "credential_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "must_change": {
+          "name": "must_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_credentials_user_id_credential_type_unique": {
+          "name": "user_credentials_user_id_credential_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "credential_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_federated_identities": {
+      "name": "user_federated_identities",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_display_name": {
+          "name": "provider_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_federated_user": {
+          "name": "idx_iam_federated_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_federated_identities_user_id_users_id_fk": {
+          "name": "user_federated_identities_user_id_users_id_fk",
+          "tableFrom": "user_federated_identities",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_federated_identities_provider_provider_user_id_unique": {
+          "name": "user_federated_identities_provider_provider_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "provider_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_mfa_recovery_codes": {
+      "name": "user_mfa_recovery_codes",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_recovery_codes_user": {
+          "name": "idx_iam_recovery_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mfa_recovery_codes_user_id_users_id_fk": {
+          "name": "user_mfa_recovery_codes_user_id_users_id_fk",
+          "tableFrom": "user_mfa_recovery_codes",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_mfa_totp": {
+      "name": "user_mfa_totp",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_encrypted": {
+          "name": "secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SHA1'"
+        },
+        "digits": {
+          "name": "digits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "period": {
+          "name": "period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_user_mfa_totp_user": {
+          "name": "idx_iam_user_mfa_totp_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mfa_totp_user_id_users_id_fk": {
+          "name": "user_mfa_totp_user_id_users_id_fk",
+          "tableFrom": "user_mfa_totp",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_otp_challenges": {
+      "name": "user_otp_challenges",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_otp_challenges_expires": {
+          "name": "idx_iam_otp_challenges_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_otp_challenges_user_id_users_id_fk": {
+          "name": "user_otp_challenges_user_id_users_id_fk",
+          "tableFrom": "user_otp_challenges",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_roles": {
+      "name": "user_roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_user_roles_user": {
+          "name": "idx_iam_user_roles_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_roles_granted_by_users_id_fk": {
+          "name": "user_roles_granted_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_user_id_role_id_unique": {
+          "name": "user_roles_user_id_role_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_sessions": {
+      "name": "user_sessions",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_sessions_user": {
+          "name": "idx_iam_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_sessions_expires": {
+          "name": "idx_iam_sessions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_sessions_signing_key_id_rsa_signing_keys_id_fk": {
+          "name": "user_sessions_signing_key_id_rsa_signing_keys_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "rsa_signing_keys",
+          "schemaTo": "iam",
+          "columnsFrom": ["signing_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_tenant_roles": {
+      "name": "user_tenant_roles",
+      "schema": "iam",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_tenant_roles_lookup": {
+          "name": "idx_user_tenant_roles_lookup",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_tenant_roles_user_id_users_id_fk": {
+          "name": "user_tenant_roles_user_id_users_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenant_roles_tenant_id_tenants_id_fk": {
+          "name": "user_tenant_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenant_roles_role_id_tenant_roles_id_fk": {
+          "name": "user_tenant_roles_role_id_tenant_roles_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "tenant_roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tenant_roles_user_id_tenant_id_role_id_pk": {
+          "name": "user_tenant_roles_user_id_tenant_id_role_id_pk",
+          "columns": ["user_id", "tenant_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/scripts/dbdeploy/db-iam/drizzle/meta/0002_snapshot.json
+++ b/scripts/dbdeploy/db-iam/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1755 @@
+{
+  "id": "9a445983-6f44-4b0a-ad4d-07c8feccc440",
+  "prevId": "3fce7e5e-3770-40dc-85ce-a63b6be4b029",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "iam.auth_audit_log": {
+      "name": "auth_audit_log",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_audit_user_created": {
+          "name": "idx_iam_audit_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_audit_event_created": {
+          "name": "idx_iam_audit_event_created",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_audit_created": {
+          "name": "idx_iam_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_audit_log_user_id_users_id_fk": {
+          "name": "auth_audit_log_user_id_users_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_audit_log_actor_id_users_id_fk": {
+          "name": "auth_audit_log_actor_id_users_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_audit_log_session_id_user_sessions_id_fk": {
+          "name": "auth_audit_log_session_id_user_sessions_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "user_sessions",
+          "schemaTo": "iam",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.fga_config": {
+      "name": "fga_config",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_model_id": {
+          "name": "auth_model_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "api_url": {
+          "name": "api_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http://127.0.0.1:8080'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.users": {
+      "name": "users",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_verified_at": {
+          "name": "phone_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_users_status": {
+          "name": "idx_iam_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": ["phone"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.permissions": {
+      "name": "permissions",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.role_permissions": {
+      "name": "role_permissions",
+      "schema": "iam",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_tenant_roles_id_fk": {
+          "name": "role_permissions_role_id_tenant_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "tenant_roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "schemaTo": "iam",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": ["role_id", "permission_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.roles": {
+      "name": "roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.rsa_signing_keys": {
+      "name": "rsa_signing_keys",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kid": {
+          "name": "kid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RS256'"
+        },
+        "key_use": {
+          "name": "key_use",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sig'"
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_size_bits": {
+          "name": "key_size_bits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2048
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_signing_keys_active": {
+          "name": "idx_iam_signing_keys_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rsa_signing_keys_kid_unique": {
+          "name": "rsa_signing_keys_kid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["kid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenant_comms_config": {
+      "name": "tenant_comms_config",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_identity": {
+          "name": "sender_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_comms_config_tenant_id_tenants_id_fk": {
+          "name": "tenant_comms_config_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_comms_config",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_comms_config_tenant_id_channel_label_unique": {
+          "name": "tenant_comms_config_tenant_id_channel_label_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "channel", "label"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenant_roles": {
+      "name": "tenant_roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_roles_tenant_id_tenants_id_fk": {
+          "name": "tenant_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_roles",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_roles_tenant_id_name_unique": {
+          "name": "tenant_roles_tenant_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenants": {
+      "name": "tenants",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_credentials": {
+      "name": "user_credentials",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'password'"
+        },
+        "credential_hash": {
+          "name": "credential_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "must_change": {
+          "name": "must_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_credentials_user_id_credential_type_unique": {
+          "name": "user_credentials_user_id_credential_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "credential_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_federated_identities": {
+      "name": "user_federated_identities",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_display_name": {
+          "name": "provider_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_federated_user": {
+          "name": "idx_iam_federated_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_federated_identities_user_id_users_id_fk": {
+          "name": "user_federated_identities_user_id_users_id_fk",
+          "tableFrom": "user_federated_identities",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_federated_identities_provider_provider_user_id_unique": {
+          "name": "user_federated_identities_provider_provider_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "provider_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_mfa_recovery_codes": {
+      "name": "user_mfa_recovery_codes",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_recovery_codes_user": {
+          "name": "idx_iam_recovery_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mfa_recovery_codes_user_id_users_id_fk": {
+          "name": "user_mfa_recovery_codes_user_id_users_id_fk",
+          "tableFrom": "user_mfa_recovery_codes",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_mfa_totp": {
+      "name": "user_mfa_totp",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_encrypted": {
+          "name": "secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SHA1'"
+        },
+        "digits": {
+          "name": "digits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "period": {
+          "name": "period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_user_mfa_totp_user": {
+          "name": "idx_iam_user_mfa_totp_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mfa_totp_user_id_users_id_fk": {
+          "name": "user_mfa_totp_user_id_users_id_fk",
+          "tableFrom": "user_mfa_totp",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_otp_challenges": {
+      "name": "user_otp_challenges",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_otp_challenges_expires": {
+          "name": "idx_iam_otp_challenges_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_otp_challenges_user_id_users_id_fk": {
+          "name": "user_otp_challenges_user_id_users_id_fk",
+          "tableFrom": "user_otp_challenges",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_roles": {
+      "name": "user_roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_user_roles_user": {
+          "name": "idx_iam_user_roles_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_roles_granted_by_users_id_fk": {
+          "name": "user_roles_granted_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_user_id_role_id_unique": {
+          "name": "user_roles_user_id_role_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_sessions": {
+      "name": "user_sessions",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_sessions_user": {
+          "name": "idx_iam_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_sessions_expires": {
+          "name": "idx_iam_sessions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_sessions_signing_key_id_rsa_signing_keys_id_fk": {
+          "name": "user_sessions_signing_key_id_rsa_signing_keys_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "rsa_signing_keys",
+          "schemaTo": "iam",
+          "columnsFrom": ["signing_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_tenant_roles": {
+      "name": "user_tenant_roles",
+      "schema": "iam",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_tenant_roles_lookup": {
+          "name": "idx_user_tenant_roles_lookup",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_tenant_roles_user_id_users_id_fk": {
+          "name": "user_tenant_roles_user_id_users_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenant_roles_tenant_id_tenants_id_fk": {
+          "name": "user_tenant_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenant_roles_role_id_tenant_roles_id_fk": {
+          "name": "user_tenant_roles_role_id_tenant_roles_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "tenant_roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tenant_roles_user_id_tenant_id_role_id_pk": {
+          "name": "user_tenant_roles_user_id_tenant_id_role_id_pk",
+          "columns": ["user_id", "tenant_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/scripts/dbdeploy/db-iam/drizzle/meta/_journal.json
+++ b/scripts/dbdeploy/db-iam/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779693827288,
       "tag": "0001_modern_shiver_man",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1779760901003,
+      "tag": "0002_strong_thanos",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/dbdeploy/db-iam/drizzle/meta/_journal.json
+++ b/scripts/dbdeploy/db-iam/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1779165338553,
       "tag": "0000_cultured_iron_man",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779693827288,
+      "tag": "0001_modern_shiver_man",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Pull Request Checklist

- [x] I read and followed the [Contribution guide](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)
- [x] I linked the related issue, if one exists
- [x] I ran the relevant checks or tests for the affected area

## Summary

Implements multi-tenant communication credentials (Issue #395). Each tenant can now configure their own sender identities for WhatsApp, Telegram, and Email — stored encrypted in the DB, resolved at runtime, and passed to the existing outbound functions.

**Key changes:**
- New `tenant_comms_config` table (iam schema) with AES-256-CBC encrypted credentials
- Credential resolver with `configure/setup` injection pattern (same as `auth/rbac.ts`)
- Admin CRUD API + Vue dashboard page for managing configs
- Refactored `sendgrid/outbound.ts` to accept credentials as parameters
- Inbound webhook routing: Telegram via path-based label, WhatsApp via phone_number_id lookup, SendGrid via sender_email + event label
- Each tenant can have multiple senders per channel (label system)
- Broadcast functions added to WhatsApp and Telegram outbound libraries

**Architecture decision — BYOK (Bring Your Own Key):**
Each tenant provides their own API keys. This was chosen because novex-kit uses Meta Cloud API directly (no BSP), which has no sub-account system. Combined with Telegram requiring one token per bot (no sharing possible), BYOK is the only model that provides consistent isolation across all channels without external dependencies.

Closes #395

## Affected Area

- [x] apps
- [x] common
- [x] docs
- [ ] scripts
- [ ] CI/CD or GitHub Actions

## Validation

```text
- TypeScript compilation passes (npx tsc --noEmit in common/compiled/node/)
- Manual testing via TenantCommsConfig.vue dashboard (create/update/delete configs)
- Manual testing via WhatsApp/Telegram/SendGrid test pages (send with selected config)
- Webhook routing verified for Telegram (path-based) and WhatsApp (phone_number_id lookup)
- SendGrid inbound parse routing verified (sender_email match)
- SendGrid event webhook routing verified (per-label + legacy custom_args)
- Broadcast functions verified for WhatsApp and Telegram (sequential + concurrent modes)
```

## Notes

### Files Added

| File | Purpose |
|------|---------|
| `common/compiled/node/comms/tenant/types.ts` | Shared interfaces (TenantCommsConfig, channel credentials, sender identity) |
| `common/compiled/node/comms/tenant/crypto.ts` | AES-256-CBC encrypt/decrypt wrapper for credentials |
| `common/compiled/node/comms/tenant/resolver.ts` | configure/setup + resolveCommsCredentials + reverse-lookup resolvers |
| `apps/sample-api/src/tenant-comms/routes.ts` | Admin CRUD API for tenant comms config |
| `apps/sample-vue-full/views/TenantCommsConfig.vue` | Dashboard UI for managing configs |
| DB migration: `add_tenant_comms_config.sql` | Table + indexes |

### Files Modified

| File | Change |
|------|--------|
| `common/compiled/node/comms/sendgrid/outbound.ts` | Accept `SendGridAuth` as first param instead of reading env |
| `common/compiled/node/comms/whatsapp2/outbound.ts` | Added `broadcast()` function |
| `common/compiled/node/comms/whatsapp2/types.ts` | Added broadcast types |
| `common/compiled/node/comms/telegram2/outbound.ts` | Added `broadcast()`, `setWebhook()`, `deleteWebhook()`, `getWebhookInfo()` |
| `common/compiled/node/comms/telegram2/types.ts` | Added broadcast types, SetWebhookOpts |
| `apps/sample-api/src/app.ts` | Call `commsTenant.configure()` + `setup()` at startup |
| `apps/sample-api/src/whatsapp/routes.ts` | Use resolver instead of env vars; multi-config webhook routing |
| `apps/sample-api/src/sendgrid/routes.ts` | Use resolver; pass auth to outbound functions |
| `apps/sample-api/src/sendgrid/webhook-routes.ts` | Inbound parse routing + per-label event webhook |
| `apps/sample-api/src/telegram/routes.ts` | Per-label webhook with secret_token verification |
| `apps/sample-api/src/database/schema-iam.ts` | Added `tenantCommsConfig` table definition |

### Environment Variables

New:
- `COMMS_ENCRYPTION_KEY` — master password for encrypting tenant credentials at rest

Removed from per-tenant use (now in DB):
- `SENDGRID_KEY`, `SENDGRID_SENDER_NAME`, `SENDGRID_SENDER_EMAIL`
- `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_BUSINESS_ACCOUNT_ID`
