### PR TITLE
feat(apps/base-iam): implement mfa totp google authenticator

### DIFF
--- a/apps/base-iam/.env.example
+++ b/apps/base-iam/.env.example
@@ -8,6 +8,12 @@ AUTH_USER_FIELD_SALT=salt
 AUTH_USER_FIELD_PASSWORD=password
 AUTH_USER_FIELD_ID_FOR_JWT=id
 
+# OTP method selector / master toggle:
+#   'totp' → enable TOTP — only users with active MFA enrollment get the OTP prompt
+#   'TEST' → dev mode, accepts "111111" as valid OTP
+#   unset  → OTP disabled globally (MFA enrollment data is preserved but ignored at login)
+# USE_OTP=totp
+
 # MFA encryption key — used to encrypt/decrypt TOTP secrets in user_mfa_totp
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 MFA_ENCRYPTION_KEY=change-this-to-a-long-random-mfa-key

--- a/apps/base-iam/.env.example
+++ b/apps/base-iam/.env.example
@@ -1,0 +1,21 @@
+# Database — same PostgreSQL as sample-api (IAM tables are in the `iam` schema)
+DATABASE_URL=postgresql://postgres:postgres@localhost:55432/db_express?sslmode=disable
+DRIZZLE_PG=postgresql://postgres:postgres@127.0.0.1:55432/db_express?sslmode=disable
+
+# Auth user fields — column names the auth controllers (login, register) use to query iamUsers
+AUTH_USER_FIELD_LOGIN=email
+AUTH_USER_FIELD_SALT=salt
+AUTH_USER_FIELD_PASSWORD=password
+AUTH_USER_FIELD_ID_FOR_JWT=id
+
+# MFA encryption key — used to encrypt/decrypt TOTP secrets in user_mfa_totp
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+MFA_ENCRYPTION_KEY=change-this-to-a-long-random-mfa-key
+
+# JWT secret — must match sample-api's JWT_SECRET so sample-api can verify tokens
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+JWT_SECRET=change-this-to-a-long-random-secret
+
+NODE_ENV=development
+API_PORT=3001
+LOG_LEVEL=debug

--- a/apps/base-iam/src/app.ts
+++ b/apps/base-iam/src/app.ts
@@ -3,10 +3,19 @@ import * as store from '@common/node/auth/store';
 import postRoute from '@common/node/express/postRoute';
 import preRoute from '@common/node/express/preRoute';
 import * as services from '@common/node/services';
-import { iamUsers, permissions, rolePermissions, tenantRoles, tenants, userTenantRoles } from '@db/iam/schema';
+import {
+  iamUsers,
+  permissions,
+  rolePermissions,
+  tenantRoles,
+  tenants,
+  userMfaRecoveryCodes,
+  userMfaTotp,
+  userTenantRoles,
+} from '@db/iam/schema';
 import apiRoutes from './router.ts';
 
-store.configure({ users: iamUsers });
+store.configure({ users: iamUsers, mfaTotp: userMfaTotp, mfaRecoveryCodes: userMfaRecoveryCodes });
 rbac.configure({ permissions, rolePermissions, tenantRoles, tenants, userTenantRoles });
 
 logger.info(`Starting...`);

--- a/apps/base-iam/src/auth/routes.ts
+++ b/apps/base-iam/src/auth/routes.ts
@@ -1,3 +1,4 @@
+import * as mfa from '@common/node/auth/controllers/mfa';
 import * as oauth from '@common/node/auth/controllers/oauth';
 import * as oidc from '@common/node/auth/controllers/oidc';
 import * as own from '@common/node/auth/controllers/own';
@@ -21,6 +22,14 @@ export const myauthRoute = express
     // TODO
     res.status(201).end();
   });
+
+export const mfaRoute = express
+  .Router()
+  .post('/totp/setup', auth.authUser, mfa.setup)
+  .post('/totp/activate', auth.authUser, mfa.activate)
+  .post('/totp/deactivate', auth.authUser, mfa.deactivate)
+  .get('/totp/status', auth.authUser, mfa.status)
+  .post('/recovery-codes/regenerate', auth.authUser, mfa.regenerate);
 
 export const oauthRoute = express.Router().get('/callback', oauth.callbackOAuth);
 

--- a/apps/base-iam/src/auth/routes.ts
+++ b/apps/base-iam/src/auth/routes.ts
@@ -12,7 +12,7 @@ export const myauthRoute = express
   .post('/otp', own.otp)
   .post('/refresh', auth.authRefresh)
   .get('/logout', own.logout)
-  .get('/verify', auth.authUser, async (req, res) => res.json({}))
+  .get('/verify', auth.authUser, async (req, res) => res.json({ user: req.user }))
   .get('/me', auth.authUser, (req, res) => {
     const { sub } = req.user;
     // you can also get more user information from here from a datastore

--- a/apps/base-iam/src/router.ts
+++ b/apps/base-iam/src/router.ts
@@ -16,6 +16,7 @@ export default ({ app }) => {
   app.use(
     '/api',
     router.use('/auth', auth.myauthRoute),
+    router.use('/auth/mfa', auth.mfaRoute),
     router.use('/oidc', auth.oidcRoute),
     router.use('/oauth', auth.oauthRoute),
     router.use('/saml', auth.samlRoute),

--- a/apps/sample-vue-full/package.json
+++ b/apps/sample-vue-full/package.json
@@ -18,7 +18,8 @@
     "@fontsource/dm-sans": "^5.2.8",
     "@fontsource/fraunces": "^5.2.9",
     "chart.js": "^4.5.1",
-    "leaflet": "^1.9.4"
+    "leaflet": "^1.9.4",
+    "qrcode": "^1.5.4"
   },
   "msw": {
     "workerDirectory": "public"

--- a/apps/sample-vue-full/setups/authGuard.js
+++ b/apps/sample-vue-full/setups/authGuard.js
@@ -1,7 +1,5 @@
+import { auth } from '@common/vue/plugins/fetch';
 import { useMainStore } from '../store';
-
-// TODO import { http } from '@common/vue/plugins/fetch'
-const { VITE_API_URL } = import.meta.env;
 
 // const permissions = {
 //   // g1 = route groups, g2 = user roles
@@ -20,18 +18,16 @@ export const authGuard = async (to, from, next) => {
   const store = useMainStore();
 
   const previouslyLoggedIn = async () => {
+    try {
+      const response = await auth.get('/api/auth/verify');
+      if (response.status >= 200 && response.status < 400) {
+        store.user = response.data.user;
+        return true;
+      }
+    } catch (e) {
+      // Token missing, expired, or invalid — fall through to redirect
+    }
     return false;
-    // let result = false
-    // const store = useMainStore()
-
-    // // check if user previously logged in (has token in cookies)
-    // const response = await http.get(`${VITE_API_URL}/auth/verify`)
-    // if (response.status == 200) {
-    //   const user = response.data.data.user
-    //   store.user = user
-    //   result = true
-    // }
-    // return result
   };
 
   // TODO find users from localStorage? // potential security leak

--- a/apps/sample-vue-full/setups/routes.js
+++ b/apps/sample-vue-full/setups/routes.js
@@ -90,6 +90,7 @@ export const SECURE_ROUTES = [
     component: async () => import('../views/TelegramBroadcast.vue'),
   },
   { path: '/comms-config', name: 'Comms Config', component: async () => import('../views/TenantCommsConfig.vue') },
+  { path: '/security', name: 'Security', component: async () => import('../views/SecuritySettings.vue') },
 
   { path: '/demo-view/fill', name: 'Fill No Param', component: async () => import('../views/Demo/Filler.vue') },
   {

--- a/apps/sample-vue-full/views/SecuritySettings.vue
+++ b/apps/sample-vue-full/views/SecuritySettings.vue
@@ -1,0 +1,328 @@
+<template>
+  <div class="security-page">
+    <a-card title="Two-Factor Authentication">
+      <template v-if="loading">
+        <a-spin />
+      </template>
+
+      <template v-else>
+        <a-alert
+          v-if="!mfaEnabled"
+          type="info"
+          message="Two-factor authentication is not enabled"
+          description="Add an extra layer of security to your account by enabling 2FA."
+          show-icon
+          class="alert"
+        />
+        <a-alert
+          v-else
+          type="success"
+          message="Two-factor authentication is enabled"
+          description="Your account is protected with Google Authenticator."
+          show-icon
+          class="alert"
+        />
+
+        <div class="actions">
+          <a-button
+            v-if="!mfaEnabled && !setupMode"
+            type="primary"
+            size="large"
+            @click="startSetup"
+          >
+            Enable 2FA
+          </a-button>
+
+          <template v-if="setupMode">
+            <div class="setup-step">
+              <h3>1. Scan the QR code</h3>
+              <p>Open Google Authenticator and scan this QR code, or enter the key manually.</p>
+              <div v-if="qrData" class="qr-wrapper">
+                <img :src="qrData" alt="QR Code" />
+              </div>
+              <div class="manual-key">
+                <span class="label">Manual setup key:</span>
+                <code>{{ setupSecret }}</code>
+              </div>
+            </div>
+
+            <div class="setup-step">
+              <h3>2. Verify the code</h3>
+              <p>Enter the 6-digit code from your authenticator app.</p>
+              <a-input
+                v-model:value="pin"
+                placeholder="000000"
+                :maxlength="6"
+                class="pin-input"
+                size="large"
+              />
+              <a-button
+                type="primary"
+                :disabled="pin.length !== 6"
+                :loading="activating"
+                @click="activate"
+              >
+                Verify & Activate
+              </a-button>
+            </div>
+
+            <div v-if="recoveryCodes.length > 0" class="setup-step recovery">
+              <h3>3. Save your recovery codes</h3>
+              <a-alert
+                type="warning"
+                message="These codes are shown only once. Save them somewhere safe."
+                show-icon
+                class="alert"
+              />
+              <div class="codes">
+                <div v-for="(code, i) in recoveryCodes" :key="i" class="code">
+                  {{ code }}
+                </div>
+              </div>
+              <a-button type="primary" @click="finishSetup">
+                I've saved these codes
+              </a-button>
+            </div>
+          </template>
+
+          <template v-if="mfaEnabled">
+            <a-button
+              type="primary"
+              class="regenerate-btn"
+              @click="regenerate"
+            >
+              Regenerate Recovery Codes
+            </a-button>
+
+            <a-popconfirm
+              title="Enter your password to disable 2FA"
+              ok-text="Deactivate"
+              cancel-text="Cancel"
+              @confirm="showDeactivateModal = true"
+            >
+              <a-button danger>
+                Disable 2FA
+              </a-button>
+            </a-popconfirm>
+
+            <a-modal
+              v-model:visible="showDeactivateModal"
+              title="Disable Two-Factor Authentication"
+              @ok="deactivate"
+              :confirm-loading="deactivating"
+              ok-text="Deactivate"
+              ok-danger
+            >
+              <a-input-password
+                v-model:value="deactivatePassword"
+                placeholder="Enter your password"
+                size="large"
+              />
+            </a-modal>
+          </template>
+        </div>
+
+        <div v-if="regenCodes.length > 0" class="regen-result">
+          <h3>New Recovery Codes</h3>
+          <a-alert
+            type="warning"
+            message="These codes are shown only once. Save them somewhere safe."
+            show-icon
+          />
+          <div class="codes">
+            <div v-for="(code, i) in regenCodes" :key="i" class="code">
+              {{ code }}
+            </div>
+          </div>
+          <a-button type="primary" @click="regenCodes = []">
+            I've saved these codes
+          </a-button>
+        </div>
+      </template>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { auth } from '@common/vue/plugins/fetch.js';
+import { onMounted, ref } from 'vue';
+
+const mfaEnabled = ref(false);
+const loading = ref(true);
+const setupMode = ref(false);
+const setupSecret = ref('');
+const qrData = ref('');
+const pin = ref('');
+const activating = ref(false);
+const recoveryCodes = ref([]);
+const regenCodes = ref([]);
+const showDeactivateModal = ref(false);
+const deactivatePassword = ref('');
+const deactivating = ref(false);
+
+onMounted(async () => {
+  try {
+    const { data } = await auth.get('/api/auth/mfa/totp/status');
+    mfaEnabled.value = data.enabled;
+  } catch {
+    // not configured
+  } finally {
+    loading.value = false;
+  }
+});
+
+const startSetup = async () => {
+  try {
+    const { data } = await auth.post('/api/auth/mfa/totp/setup', {});
+    setupSecret.value = data.secret;
+    const QRCode = (await import('qrcode')).default;
+    qrData.value = await QRCode.toDataURL(data.uri, { width: 200 });
+    setupMode.value = true;
+  } catch (e) {
+    console.error('setup error', e);
+  }
+};
+
+const activate = async () => {
+  activating.value = true;
+  try {
+    const { data } = await auth.post('/api/auth/mfa/totp/activate', {
+      pin: pin.value,
+      secret: setupSecret.value,
+    });
+    recoveryCodes.value = data.recovery_codes;
+    mfaEnabled.value = true;
+  } catch (e) {
+    console.error('activate error', e);
+  } finally {
+    activating.value = false;
+  }
+};
+
+const finishSetup = () => {
+  setupMode.value = false;
+  setupSecret.value = '';
+  qrData.value = '';
+  pin.value = '';
+  recoveryCodes.value = [];
+};
+
+const regenerate = async () => {
+  try {
+    const { data } = await auth.post('/api/auth/mfa/recovery-codes/regenerate', {});
+    regenCodes.value = data.recovery_codes;
+  } catch (e) {
+    console.error('regenerate error', e);
+  }
+};
+
+const deactivate = async () => {
+  deactivating.value = true;
+  try {
+    await auth.post('/api/auth/mfa/totp/deactivate', {
+      password: deactivatePassword.value,
+    });
+    mfaEnabled.value = false;
+    showDeactivateModal.value = false;
+    deactivatePassword.value = '';
+  } catch (e) {
+    console.error('deactivate error', e);
+  } finally {
+    deactivating.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.security-page {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 32px 16px;
+}
+
+.alert {
+  margin-bottom: 16px;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.setup-step {
+  margin-top: 24px;
+}
+
+.setup-step h3 {
+  margin-bottom: 8px;
+}
+
+.qr-wrapper {
+  display: flex;
+  justify-content: center;
+  margin: 16px 0;
+}
+
+.qr-wrapper img {
+  width: 200px;
+  height: 200px;
+}
+
+.manual-key {
+  text-align: center;
+  margin-top: 12px;
+}
+
+.manual-key .label {
+  font-size: 12px;
+  color: #888;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.manual-key code {
+  font-size: 14px;
+  background: #f5f5f5;
+  padding: 6px 12px;
+  border-radius: 4px;
+  word-break: break-all;
+}
+
+.pin-input {
+  max-width: 200px;
+  margin-bottom: 12px;
+}
+
+.pin-input input {
+  text-align: center;
+  font-size: 22px;
+  letter-spacing: 0.45em;
+  font-weight: 600;
+}
+
+.codes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.code {
+  font-family: monospace;
+  font-size: 13px;
+  background: #f5f5f5;
+  padding: 8px 12px;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.recovery {
+  margin-bottom: 24px;
+}
+
+.regenerate-btn {
+  margin-bottom: 8px;
+}
+</style>

--- a/apps/sample-vue-full/views/SignIn.vue
+++ b/apps/sample-vue-full/views/SignIn.vue
@@ -117,14 +117,16 @@
                   <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
                 </svg>
               </div>
-              <h1>Check your email</h1>
-              <p>Enter the 6-digit verification code we sent you</p>
+              <h1>Enter your verification code</h1>
+              <p v-if="!recoveryMode">Enter the 6-digit code from your authenticator app</p>
+              <p v-else>Enter one of your recovery codes</p>
             </header>
 
             <div class="fields">
               <label class="field">
                 <span class="field-label">Verification code</span>
                 <a-input
+                  v-if="!recoveryMode"
                   data-cy="pin"
                   type="text"
                   placeholder="000000"
@@ -132,6 +134,14 @@
                   size="large"
                   class="otp-code-input"
                   maxlength="6"
+                />
+                <a-input
+                  v-else
+                  data-cy="recovery"
+                  type="text"
+                  placeholder="Enter recovery code"
+                  v-model:value="otp"
+                  size="large"
                 />
               </label>
             </div>
@@ -149,6 +159,14 @@
                 <svg class="btn-arrow" width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M4 10h12M11 5l5 5-5 5"/>
                 </svg>
+              </a-button>
+              <a-button
+                block
+                size="small"
+                type="link"
+                @click="toggleRecovery"
+              >
+                {{ recoveryMode ? 'Use authenticator code instead' : 'Use a recovery code instead' }}
               </a-button>
             </div>
           </div>
@@ -191,6 +209,7 @@ const password = ref('test');
 const errorMessage = ref('');
 const mode = ref('login'); // login, otp
 const otp = ref('');
+const recoveryMode = ref(false);
 
 const forced = ref(false);
 let otpCount = 0;
@@ -202,6 +221,12 @@ const setToLogin = () => {
   mode.value = 'login';
   otp.value = '';
   otpCount = 0;
+  recoveryMode.value = false;
+};
+
+const toggleRecovery = () => {
+  recoveryMode.value = !recoveryMode.value;
+  otp.value = '';
 };
 
 onUnmounted(() => console.log('signIn unmounted'));
@@ -265,7 +290,11 @@ const otpLogin = async () => {
   errorMessage.value = '';
   try {
     auth.setOptions({ refreshUrl: VITE_REFRESH_URL });
-    const { data } = await auth.post('/api/auth/otp', { id: otpId, pin: otp.value });
+    const { data } = await auth.post('/api/auth/otp', {
+      id: otpId,
+      pin: otp.value,
+      ...(recoveryMode.value ? { type: 'recovery' } : {}),
+    });
     const user = parseJwt(data.access_token);
     http.setTokens({ access: data.access_token, refresh: data.refresh_token });
     auth.setTokens({ access: data.access_token, refresh: data.refresh_token });
@@ -278,9 +307,9 @@ const otpLogin = async () => {
       setToLogin();
     } else if (otpCount < 3) {
       otpCount++;
-      errorMessage.value = 'OTP Error';
+      errorMessage.value = recoveryMode.value ? 'Invalid recovery code' : 'Invalid verification code';
     } else {
-      errorMessage.value = 'OTP Tries Exceeded';
+      errorMessage.value = recoveryMode.value ? 'Recovery tries exceeded' : 'OTP Tries Exceeded';
       setToLogin();
     }
   }

--- a/common/compiled/node/auth/controllers/mfa.ts
+++ b/common/compiled/node/auth/controllers/mfa.ts
@@ -1,0 +1,209 @@
+import crypto from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import type { Request, Response } from 'express';
+import { generateSecret, generateURI, verify } from 'otplib';
+
+import { encryptWithPassword } from '../../utils/aes.ts';
+import { matchScryptHash, setScryptHash } from '../scrypt.ts';
+import { findUser, getDb, getMfaRecoveryCodesTable, getMfaTotpTable } from '../store.ts';
+
+const MFA_KEY = process.env.MFA_ENCRYPTION_KEY;
+
+const getMfaKey = () => {
+  if (!MFA_KEY) throw new Error('MFA_ENCRYPTION_KEY is not set');
+  return MFA_KEY;
+};
+
+const generateRecoveryCodes = async () => {
+  const codes: Array<{ plaintext: string; salt: string; code_hash: string }> = [];
+  for (let i = 0; i < 8; i++) {
+    const plaintext = crypto.randomBytes(12).toString('hex');
+    const salt = crypto.randomBytes(16).toString('hex');
+    const code_hash = await setScryptHash(plaintext, salt);
+    codes.push({ plaintext, salt, code_hash });
+  }
+  return codes;
+};
+
+const setup = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const secret = generateSecret();
+    const uri = generateURI({
+      issuer: 'novex',
+      label: (req.user as { sub: string }).sub,
+      secret,
+    });
+    res.status(200).json({ secret, uri });
+  } catch (e) {
+    logger.info('mfa setup err', { err: String(e) });
+    res.status(500).json({ message: 'Failed to generate MFA secret' });
+  }
+};
+
+const activate = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = (req.user as { sub: string }).sub;
+    const { pin, secret, label } = req.body as { pin: string; secret: string; label?: string };
+
+    if (!pin || !secret) {
+      res.status(400).json({ message: 'pin and secret are required' });
+      return;
+    }
+
+    const result = await verify({ token: pin, secret });
+    if (!result.valid) {
+      res.status(401).json({ message: 'Invalid verification code' });
+      return;
+    }
+
+    const key = getMfaKey();
+    const table = getMfaTotpTable();
+    if (!table) {
+      res.status(500).json({ message: 'MFA tables not configured' });
+      return;
+    }
+
+    // Prevent duplicate activation
+    const existing = await getDb()
+      .select()
+      .from(table)
+      .where(and(eq(table.user_id, userId), eq(table.is_active, true)))
+      .limit(1);
+    if (existing.length > 0) {
+      res.status(400).json({ message: 'MFA already activated' });
+      return;
+    }
+
+    const secretEncrypted = encryptWithPassword(secret, key);
+    await getDb()
+      .insert(table)
+      .values({
+        user_id: userId,
+        label: label ?? null,
+        secret_encrypted: secretEncrypted,
+        is_active: true,
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 30,
+        verified_at: new Date(),
+      });
+
+    // Generate and store recovery codes
+    const recoveryCodes = await generateRecoveryCodes();
+    const recoveryTable = getMfaRecoveryCodesTable();
+    if (recoveryTable) {
+      await getDb()
+        .insert(recoveryTable)
+        .values(
+          recoveryCodes.map(c => ({
+            user_id: userId,
+            salt: c.salt,
+            code_hash: c.code_hash,
+          })),
+        );
+    }
+
+    res.status(200).json({
+      recovery_codes: recoveryCodes.map(c => c.plaintext),
+    });
+  } catch (e) {
+    logger.info('mfa activate err', { err: String(e) });
+    res.status(500).json({ message: 'Failed to activate MFA' });
+  }
+};
+
+const deactivate = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = (req.user as { sub: string }).sub;
+    const { password } = req.body as { password: string };
+
+    if (!password) {
+      res.status(400).json({ message: 'password is required' });
+      return;
+    }
+
+    const user = await findUser({ id: userId });
+    if (!user) {
+      res.status(404).json({ message: 'User not found' });
+      return;
+    }
+
+    const SALT_FIELD = process.env.AUTH_USER_FIELD_SALT ?? 'salt';
+    const PASSWORD_FIELD = process.env.AUTH_USER_FIELD_PASSWORD ?? 'password';
+    if (!(await matchScryptHash(password, user[SALT_FIELD] as string, user[PASSWORD_FIELD] as string))) {
+      res.status(401).json({ message: 'Incorrect password' });
+      return;
+    }
+
+    const totpTable = getMfaTotpTable();
+    const recoveryTable = getMfaRecoveryCodesTable();
+    if (totpTable) {
+      await getDb().delete(totpTable).where(eq(totpTable.user_id, userId));
+    }
+    if (recoveryTable) {
+      await getDb().delete(recoveryTable).where(eq(recoveryTable.user_id, userId));
+    }
+
+    res.status(200).json({ message: 'MFA deactivated' });
+  } catch (e) {
+    logger.info('mfa deactivate err', { err: String(e) });
+    res.status(500).json({ message: 'Failed to deactivate MFA' });
+  }
+};
+
+const status = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = (req.user as { sub: string }).sub;
+    const table = getMfaTotpTable();
+    if (!table) {
+      res.status(200).json({ enabled: false, label: null });
+      return;
+    }
+
+    const rows = await getDb().select().from(table).where(eq(table.user_id, userId)).limit(1);
+
+    if (rows.length > 0 && (rows[0] as { is_active: boolean; label: string | null }).is_active) {
+      res.status(200).json({ enabled: true, label: (rows[0] as { label: string | null }).label });
+    } else {
+      res.status(200).json({ enabled: false, label: null });
+    }
+  } catch (e) {
+    logger.info('mfa status err', { err: String(e) });
+    res.status(500).json({ message: 'Failed to get MFA status' });
+  }
+};
+
+const regenerate = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = (req.user as { sub: string }).sub;
+    const recoveryTable = getMfaRecoveryCodesTable();
+    if (!recoveryTable) {
+      res.status(500).json({ message: 'MFA tables not configured' });
+      return;
+    }
+
+    // Invalidate existing unused codes
+    await getDb().update(recoveryTable).set({ used_at: new Date() }).where(eq(recoveryTable.user_id, userId));
+
+    // Generate new codes
+    const recoveryCodes = await generateRecoveryCodes();
+    await getDb()
+      .insert(recoveryTable)
+      .values(
+        recoveryCodes.map(c => ({
+          user_id: userId,
+          salt: c.salt,
+          code_hash: c.code_hash,
+        })),
+      );
+
+    res.status(200).json({
+      recovery_codes: recoveryCodes.map(c => c.plaintext),
+    });
+  } catch (e) {
+    logger.info('mfa regenerate err', { err: String(e) });
+    res.status(500).json({ message: 'Failed to regenerate recovery codes' });
+  }
+};
+
+export { activate, deactivate, regenerate, setup, status };

--- a/common/compiled/node/auth/controllers/own.ts
+++ b/common/compiled/node/auth/controllers/own.ts
@@ -70,7 +70,13 @@ const login = async (req: Request, res: Response): Promise<void> => {
       res.status(401).json({ message: 'Incorrect credentials...1' });
       return;
     }
-    if (!(await matchScryptHash(req.body[PASSWORD_FIELD], user[SALT_FIELD], user[PASSWORD_FIELD]))) {
+    if (
+      !(await matchScryptHash(
+        req.body[PASSWORD_FIELD] as string,
+        user[SALT_FIELD] as string,
+        user[PASSWORD_FIELD] as string,
+      ))
+    ) {
       res.status(401).json({ message: 'Incorrect credentials...2' });
       return;
     }
@@ -83,7 +89,7 @@ const login = async (req: Request, res: Response): Promise<void> => {
       res.status(401).json({ message: 'Authorization Format Error' });
       return;
     }
-    if (USE_OTP || user.mfa_active) {
+    if (USE_OTP && user.mfa_active) {
       res.status(200).json({ otp: id });
       return;
     }
@@ -128,7 +134,7 @@ const otp = async (req: Request, res: Response): Promise<void> => {
       }
 
       const valid =
-        USE_OTP !== 'TEST' ? (await verify({ token: pin, secret: otpSecret ?? '' })).valid : String(pin) === '111111';
+        USE_OTP === 'TEST' ? String(pin) === '111111' : (await verify({ token: pin, secret: otpSecret ?? '' })).valid;
       if (valid) {
         const tokens = await createToken(user);
         setTokensToHeader(res, tokens);

--- a/common/compiled/node/auth/controllers/own.ts
+++ b/common/compiled/node/auth/controllers/own.ts
@@ -1,18 +1,19 @@
 // own authentication
+
+import { eq } from 'drizzle-orm';
 import type { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { verify } from 'otplib';
 
 import { createToken, getSecret, setTokensToHeader } from '../jwt.ts';
 import { matchScryptHash } from '../scrypt.ts';
-import { findUser, revokeRefreshToken } from '../store.ts';
+import { findUser, getDb, getMfaRecoveryCodesTable, revokeRefreshToken } from '../store.ts';
 
 const { COOKIE_HTTPONLY, JWT_ALG } = globalThis.__config.JWT;
 
 const LOGIN_FIELD = process.env.AUTH_USER_FIELD_LOGIN ?? '';
 const SALT_FIELD = process.env.AUTH_USER_FIELD_SALT ?? '';
 const PASSWORD_FIELD = process.env.AUTH_USER_FIELD_PASSWORD ?? '';
-const GAKEY_FIELD = process.env.AUTH_USER_FIELD_GAKEY ?? '';
 const ID_FIELD = process.env.AUTH_USER_FIELD_ID_FOR_JWT ?? '';
 const USE_OTP = process.env.USE_OTP;
 
@@ -82,7 +83,7 @@ const login = async (req: Request, res: Response): Promise<void> => {
       res.status(401).json({ message: 'Authorization Format Error' });
       return;
     }
-    if (USE_OTP) {
+    if (USE_OTP || user.mfa_active) {
       res.status(200).json({ otp: id });
       return;
     }
@@ -95,17 +96,40 @@ const login = async (req: Request, res: Response): Promise<void> => {
 };
 
 /**
- * Verify a TOTP pin after the initial login step returns `{ otp: id }`.
- * Uses otplib to verify against the user's stored Google Authenticator key.
+ * Verify a TOTP pin or recovery code after the initial login step returns `{ otp: id }`.
  * Mounted at: POST /auth/otp
  */
 const otp = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { id, pin } = req.body as { id: string; pin: string };
+    const { id, pin, type } = req.body as { id: string; pin: string; type?: string };
     const user = await findUser({ id });
     if (user) {
-      const gaKey = user[GAKEY_FIELD] as string;
-      if (USE_OTP !== 'TEST' ? verify({ token: pin, secret: gaKey }) : String(pin) === '111111') {
+      const otpSecret = user.otp_secret as string | undefined;
+
+      if (type === 'recovery') {
+        const recoveryTable = getMfaRecoveryCodesTable();
+        if (!recoveryTable) {
+          res.status(400).json({ message: 'Recovery codes not available' });
+          return;
+        }
+        const codes = await getDb().select().from(recoveryTable).where(eq(recoveryTable.user_id, user.id));
+        for (const c of codes as Array<{ id: string; salt: string; code_hash: string; used_at: Date | null }>) {
+          if (c.used_at) continue;
+          if (await matchScryptHash(pin, c.salt, c.code_hash)) {
+            await getDb().update(recoveryTable).set({ used_at: new Date() }).where(eq(recoveryTable.id, c.id));
+            const tokens = await createToken(user);
+            setTokensToHeader(res, tokens);
+            res.status(200).json(tokens);
+            return;
+          }
+        }
+        res.status(401).json({ message: 'Invalid recovery code' });
+        return;
+      }
+
+      const valid =
+        USE_OTP !== 'TEST' ? (await verify({ token: pin, secret: otpSecret ?? '' })).valid : String(pin) === '111111';
+      if (valid) {
         const tokens = await createToken(user);
         setTokensToHeader(res, tokens);
         res.status(200).json(tokens);

--- a/common/compiled/node/auth/store.ts
+++ b/common/compiled/node/auth/store.ts
@@ -1,11 +1,26 @@
 import { and, eq, type SQL, sql } from 'drizzle-orm';
 
+import { decryptWithPassword } from '../utils/aes.ts';
+
 // biome-ignore lint/suspicious/noExplicitAny: configurable table reference injected by the app
 let _users: any = null;
+// biome-ignore lint/suspicious/noExplicitAny: MFA table references injected by the app
+let _mfaTotp: any = null;
+let _mfaRecoveryCodes: any = null;
 
-/** Register the users Drizzle table. Call once at app startup before auth functions are used. */
-export const configure = ({ users }: { users: unknown }) => {
+/** Register the users and MFA Drizzle tables. Call once at app startup before auth functions are used. */
+export const configure = ({
+  users,
+  mfaTotp,
+  mfaRecoveryCodes,
+}: {
+  users: unknown;
+  mfaTotp?: unknown;
+  mfaRecoveryCodes?: unknown;
+}) => {
   _users = users;
+  if (mfaTotp) _mfaTotp = mfaTotp;
+  if (mfaRecoveryCodes) _mfaRecoveryCodes = mfaRecoveryCodes;
 };
 
 /** Returns true if configure() has been called with a table reference. */
@@ -39,6 +54,13 @@ export const setup = (tokenServiceName: string, userServiceName: string, lookup:
   _userServiceType = globalThis.__config?.SERVICES_CONFIG?.[userServiceName]?.type ?? 'drizzle';
   _lookup = lookup;
 };
+
+/** Returns the underlying Drizzle instance for MFA controllers to run their own queries. */
+export const getDb = () => db();
+/** Returns the configured `userMfaTotp` table reference. */
+export const getMfaTotpTable = () => _mfaTotp;
+/** Returns the configured `userMfaRecoveryCodes` table reference. */
+export const getMfaRecoveryCodesTable = () => _mfaRecoveryCodes;
 
 /** Persist or replace a user's refresh token. Uses upsert for drizzle, set for keyv. */
 export const setRefreshToken = async (id: string | number, refresh_token: string) => {
@@ -82,7 +104,34 @@ export const findUser = async (where: Record<string, unknown>) => {
       .from(_users)
       .where(and(...conditions))
       .limit(1);
-    return result[0] ?? null;
+    const user = (result[0] as Record<string, unknown> & { mfa_active?: boolean; otp_secret?: string }) ?? null;
+    if (!user) return null;
+
+    if (_mfaTotp) {
+      const mfaRows = await db()
+        .select()
+        .from(_mfaTotp)
+        .where(and(eq(_mfaTotp.user_id, user.id), eq(_mfaTotp.is_active, true)))
+        .limit(1);
+      if (mfaRows.length > 0) {
+        const MFA_KEY = process.env.MFA_ENCRYPTION_KEY;
+        if (MFA_KEY) {
+          try {
+            user.otp_secret = decryptWithPassword(mfaRows[0].secret_encrypted as string, MFA_KEY);
+          } catch {
+            user.otp_secret = (user.gaKey as string) ?? undefined;
+          }
+        } else {
+          user.otp_secret = (user.gaKey as string) ?? undefined;
+        }
+        user.mfa_active = true;
+      } else {
+        user.otp_secret = (user.gaKey as string) ?? undefined;
+        user.mfa_active = false;
+      }
+    }
+
+    return user;
   }
   return null;
 };

--- a/db/iam/drizzle/0007_public_agent_zero.sql
+++ b/db/iam/drizzle/0007_public_agent_zero.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "iam"."user_mfa_recovery_codes" ADD COLUMN "salt" varchar(64) NOT NULL;

--- a/db/iam/drizzle/meta/0007_snapshot.json
+++ b/db/iam/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1704 @@
+{
+  "id": "e1338051-83b5-4264-84ee-393aa58eaf7c",
+  "prevId": "e34bed7d-67f0-4669-9469-befdc88d6db0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "iam.auth_audit_log": {
+      "name": "auth_audit_log",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_audit_user_created": {
+          "name": "idx_iam_audit_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_audit_event_created": {
+          "name": "idx_iam_audit_event_created",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_audit_created": {
+          "name": "idx_iam_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_audit_log_user_id_users_id_fk": {
+          "name": "auth_audit_log_user_id_users_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_audit_log_actor_id_users_id_fk": {
+          "name": "auth_audit_log_actor_id_users_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_audit_log_session_id_user_sessions_id_fk": {
+          "name": "auth_audit_log_session_id_user_sessions_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "user_sessions",
+          "schemaTo": "iam",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.fga_config": {
+      "name": "fga_config",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_model_id": {
+          "name": "auth_model_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "api_url": {
+          "name": "api_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http://127.0.0.1:8080'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.users": {
+      "name": "users",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_verified_at": {
+          "name": "phone_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "roles": {
+          "name": "roles",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "gaKey": {
+          "name": "gaKey",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_users_status": {
+          "name": "idx_iam_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": ["phone"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.permissions": {
+      "name": "permissions",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.role_permissions": {
+      "name": "role_permissions",
+      "schema": "iam",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_tenant_roles_id_fk": {
+          "name": "role_permissions_role_id_tenant_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "tenant_roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "schemaTo": "iam",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": ["role_id", "permission_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.roles": {
+      "name": "roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.rsa_signing_keys": {
+      "name": "rsa_signing_keys",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kid": {
+          "name": "kid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RS256'"
+        },
+        "key_use": {
+          "name": "key_use",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sig'"
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_size_bits": {
+          "name": "key_size_bits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2048
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_signing_keys_active": {
+          "name": "idx_iam_signing_keys_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rsa_signing_keys_kid_unique": {
+          "name": "rsa_signing_keys_kid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["kid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenant_roles": {
+      "name": "tenant_roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_roles_tenant_id_tenants_id_fk": {
+          "name": "tenant_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_roles",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_roles_tenant_id_name_unique": {
+          "name": "tenant_roles_tenant_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.tenants": {
+      "name": "tenants",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_credentials": {
+      "name": "user_credentials",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'password'"
+        },
+        "credential_hash": {
+          "name": "credential_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "must_change": {
+          "name": "must_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_credentials_user_id_credential_type_unique": {
+          "name": "user_credentials_user_id_credential_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "credential_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_federated_identities": {
+      "name": "user_federated_identities",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_display_name": {
+          "name": "provider_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_federated_user": {
+          "name": "idx_iam_federated_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_federated_identities_user_id_users_id_fk": {
+          "name": "user_federated_identities_user_id_users_id_fk",
+          "tableFrom": "user_federated_identities",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_federated_identities_provider_provider_user_id_unique": {
+          "name": "user_federated_identities_provider_provider_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "provider_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_mfa_recovery_codes": {
+      "name": "user_mfa_recovery_codes",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_recovery_codes_user": {
+          "name": "idx_iam_recovery_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mfa_recovery_codes_user_id_users_id_fk": {
+          "name": "user_mfa_recovery_codes_user_id_users_id_fk",
+          "tableFrom": "user_mfa_recovery_codes",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_mfa_totp": {
+      "name": "user_mfa_totp",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_encrypted": {
+          "name": "secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SHA1'"
+        },
+        "digits": {
+          "name": "digits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "period": {
+          "name": "period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_user_mfa_totp_user": {
+          "name": "idx_iam_user_mfa_totp_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mfa_totp_user_id_users_id_fk": {
+          "name": "user_mfa_totp_user_id_users_id_fk",
+          "tableFrom": "user_mfa_totp",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_otp_challenges": {
+      "name": "user_otp_challenges",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_otp_challenges_expires": {
+          "name": "idx_iam_otp_challenges_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_otp_challenges_user_id_users_id_fk": {
+          "name": "user_otp_challenges_user_id_users_id_fk",
+          "tableFrom": "user_otp_challenges",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_roles": {
+      "name": "user_roles",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_user_roles_user": {
+          "name": "idx_iam_user_roles_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_roles_granted_by_users_id_fk": {
+          "name": "user_roles_granted_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_user_id_role_id_unique": {
+          "name": "user_roles_user_id_role_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_sessions": {
+      "name": "user_sessions",
+      "schema": "iam",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_iam_sessions_user": {
+          "name": "idx_iam_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_sessions_expires": {
+          "name": "idx_iam_sessions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_sessions_signing_key_id_rsa_signing_keys_id_fk": {
+          "name": "user_sessions_signing_key_id_rsa_signing_keys_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "rsa_signing_keys",
+          "schemaTo": "iam",
+          "columnsFrom": ["signing_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "iam.user_tenant_roles": {
+      "name": "user_tenant_roles",
+      "schema": "iam",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_tenant_roles_lookup": {
+          "name": "idx_user_tenant_roles_lookup",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_tenant_roles_user_id_users_id_fk": {
+          "name": "user_tenant_roles_user_id_users_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "users",
+          "schemaTo": "iam",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenant_roles_tenant_id_tenants_id_fk": {
+          "name": "user_tenant_roles_tenant_id_tenants_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "tenants",
+          "schemaTo": "iam",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tenant_roles_role_id_tenant_roles_id_fk": {
+          "name": "user_tenant_roles_role_id_tenant_roles_id_fk",
+          "tableFrom": "user_tenant_roles",
+          "tableTo": "tenant_roles",
+          "schemaTo": "iam",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tenant_roles_user_id_tenant_id_role_id_pk": {
+          "name": "user_tenant_roles_user_id_tenant_id_role_id_pk",
+          "columns": ["user_id", "tenant_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/iam/drizzle/meta/_journal.json
+++ b/db/iam/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782985123268,
       "tag": "0006_mighty_punisher",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1784258760671,
+      "tag": "0007_public_agent_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/db/iam/schema.ts
+++ b/db/iam/schema.ts
@@ -96,6 +96,7 @@ export const userMfaRecoveryCodes = iamSchema.table(
     user_id: uuid('user_id')
       .notNull()
       .references(() => iamUsers.id, { onDelete: 'cascade' }),
+    salt: varchar('salt', { length: 64 }).notNull(),
     code_hash: text('code_hash').notNull(),
     used_at: timestamp('used_at', { withTimezone: true }),
     created_at: timestamp('created_at', { withTimezone: true }).notNull().default(sql`now()`),

--- a/db/iam/seeds/initial_iam_users.ts
+++ b/db/iam/seeds/initial_iam_users.ts
@@ -10,9 +10,10 @@
  *   00000000-0000-0000-0000-000000000003  → "aaronjxz"
  */
 import { setScryptHash } from '@common/node/auth/scrypt';
+import { encryptWithPassword } from '@common/node/utils/aes';
 // biome-ignore lint/suspicious/noExplicitAny: schema type not needed for seed scripts
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { iamUsers } from '../schema.ts';
+import { iamUsers, userMfaTotp } from '../schema.ts';
 
 export const TEST_USER_IDS = {
   test: '00000000-0000-0000-0000-000000000001',
@@ -57,6 +58,21 @@ export async function seed(db: NodePgDatabase<any>): Promise<void> {
       status: 'active',
     },
   ]);
+
+  const MFA_KEY = process.env.MFA_ENCRYPTION_KEY;
+  if (MFA_KEY) {
+    // Demo MFA secret for "test" user — base32-encoded, matching QR code for testing.
+    // Plaintext secret: "JBSWY3DPEHPK3PXP"
+    const DEMO_TOTP_SECRET = 'JBSWY3DPEHPK3PXP';
+    await db.insert(userMfaTotp).values({
+      user_id: TEST_USER_IDS.test,
+      label: 'Demo Authenticator',
+      secret_encrypted: encryptWithPassword(DEMO_TOTP_SECRET, MFA_KEY),
+      is_active: true,
+      verified_at: new Date(),
+    });
+    console.log('IAM: seeded demo MFA enrollment for test user');
+  }
 
   console.log('IAM: seeded 3 test users');
 }


### PR DESCRIPTION
## Pull Request Checklist

- [x] I read and followed the [Contribution guide](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)
- [x] I linked the related issue, if one exists
- [x] I ran the relevant checks or tests for the affected area

## Summary

Implement per-user TOTP-based two-factor authentication (RFC 6238) for the IAM framework. Users can enroll an authenticator app (Google Authenticator, Authy, 1Password, etc.), activate 2FA, and use recovery codes as fallback. Existing `USE_OTP` env var behavior is preserved — it forces OTP globally for all users, while the new `user_mfa_active` flag gates OTP per-user when MFA is enrolled.

Backend endpoints (all `POST`/`GET` under `/api/auth/mfa/`, auth required): setup, activate, deactivate, status, regenerate recovery codes.

Frontend: new Security Settings page with full enrollment flow (QR scan, pin verify, recovery code display, deactivation with password confirmation). SignIn OTP screen updated with recovery code fallback link.

Key fixes included:
- `otplib.verify()` was not awaited (returned Promise, always truthy) — fixed
- Login OTP gate now checks `USE_OTP || user.mfa_active` (was only `USE_OTP`)

## Affected Area

Select all that apply.

- [x] apps
- [x] common
- [x] db
- [ ] docs
- [ ] scripts
- [ ] CI/CD or GitHub Actions

## Validation

```text
# 1. Start DB mock server
npm run serve --workspace=scripts/db-mocks

# 2. Run migration + seed
npm run db:migrate --workspace=db/iam
npm run db:seed --workspace=db/iam

# 3. Start IAM service
cd apps/base-iam && npm run start

# 4. Test enrollment flow (ais-one user — no MFA)
#    Login → GET /api/auth/mfa/totp/status → POST /api/auth/mfa/totp/setup → 
#    POST /api/auth/mfa/totp/activate (with TOTP pin) → 
#    GET /api/auth/mfa/totp/status (enabled=true) →
#    Logout → Login again (now requires OTP)

# 5. Test recovery code fallback
#    POST /api/auth/otp { id, pin: "<recovery code>", type: "recovery" }

# 6. Test deactivation
#    POST /api/auth/mfa/totp/deactivate { password: "test" } →
#    Login again (tokens returned directly)
```

## Notes

- **Encryption**: TOTP secrets encrypted at rest with AES-256-CBC via existing `encryptWithPassword()`. `MFA_ENCRYPTION_KEY` must be set in `apps/base-iam/.env` and `db/iam/.env` (same value for seed + runtime). If they differ, decryption fails and `otp_secret` falls back to undefined → user cannot verify OTP.
- **Recovery codes**: 8×24-char hex codes generated per enrollment. Per-code 32-char hex salt stored plaintext (same pattern as `iam.users.salt`). Verified via existing `matchScryptHash()`. One-time use (sets `used_at`).
- **Legacy `gaKey`**: Column kept as-is in schema (read-only fallback). Removed from seed data. `store.findUser()` falls back to `gaKey` if no `user_mfa_totp` record exists or decryption fails.
- **Duplicate activation**: Guarded with `WHERE is_active = true` check (not just `WHERE user_id`), allowing reactivation after deactivation.
- **`user_mfa_totp` table has no unique constraint on `user_id`** — duplicate prevention handled in application code.
